### PR TITLE
Add post-signup onboarding flow

### DIFF
--- a/app/src/app/api/ai/generate/route.ts
+++ b/app/src/app/api/ai/generate/route.ts
@@ -23,7 +23,10 @@ export async function POST(request: NextRequest) {
 
     const client = getAnthropicClient();
     const prompt = buildGeneratePrompt(
-      body.productContext,
+      {
+        ...body.productContext,
+        writingStyles: body.productContext.writingStyles,
+      },
       body.examplePosts,
       body.count || 2
     );

--- a/app/src/app/api/ai/suggest-subreddits/route.ts
+++ b/app/src/app/api/ai/suggest-subreddits/route.ts
@@ -2,6 +2,82 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAnthropicClient, AI_MODEL } from '@/lib/ai/client';
 import { SUGGEST_SUBREDDITS_SYSTEM_PROMPT, buildSuggestSubredditsPrompt } from '@/lib/ai/prompts';
 
+const REDDIT_BASE = 'https://www.reddit.com';
+const USER_AGENT = 'web:superreddit:v1.0.0 (by /u/superreddit_app)';
+
+// Extract search terms from product info for Reddit subreddit search
+// Target audience terms come first since they describe the actual communities we're looking for
+function extractSearchTerms(name: string, description: string, audience?: string): string[] {
+  const terms: string[] = [];
+
+  // Target audience is the highest priority — these are the communities we want to find
+  if (audience) {
+    // Split by commas to get each audience segment, then use each as a search term
+    const segments = audience.split(',').map((s) => s.trim()).filter((s) => s.length > 2);
+    segments.forEach((seg) => terms.push(seg));
+
+    // Also create condensed no-space versions of audience segments (matches subreddit names like "OnePieceTCGFinance")
+    segments.forEach((seg) => {
+      const condensed = seg.replace(/\s+/g, '');
+      if (condensed !== seg) terms.push(condensed);
+    });
+  }
+
+  // Product name + condensed version
+  terms.push(name);
+  const condensedName = name.replace(/\s+/g, '');
+  if (condensedName !== name) terms.push(condensedName);
+
+  // Extract capitalized phrases from description (proper nouns, brand names, etc.)
+  const capitalMatches = description.match(/[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*/g);
+  if (capitalMatches) {
+    const stopPhrases = new Set(['the', 'this', 'that', 'with', 'from', 'into', 'also']);
+    capitalMatches.forEach((m) => {
+      if (m.length > 3 && !stopPhrases.has(m.toLowerCase())) {
+        terms.push(m);
+      }
+    });
+  }
+
+  // Dedupe (case-insensitive) and take up to 15 terms
+  const seen = new Set<string>();
+  return terms.filter((t) => {
+    const key = t.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  }).slice(0, 15);
+}
+
+async function searchRedditSubreddits(query: string): Promise<{ name: string; subscribers: number; description: string }[]> {
+  try {
+    const url = `${REDDIT_BASE}/subreddits/search.json?q=${encodeURIComponent(query)}&limit=10&raw_json=1`;
+    const res = await fetch(url, {
+      headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+    });
+    if (!res.ok) return [];
+    const json = await res.json() as { data: { children: Array<{ data: Record<string, unknown> }> } };
+    return json.data.children.map((c) => ({
+      name: c.data.display_name as string,
+      subscribers: (c.data.subscribers as number) || 0,
+      description: ((c.data.public_description as string) || '').slice(0, 200),
+    }));
+  } catch {
+    return [];
+  }
+}
+
+async function verifySubredditExists(name: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${REDDIT_BASE}/r/${name}/about.json`, {
+      headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
@@ -13,14 +89,55 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Step 1: Search Reddit for real subreddits
+    // If user already picked subreddits, use those as primary search terms to find related communities
+    const existingSubreddits: string[] = body.existingSubreddits || [];
+    const searchTerms = existingSubreddits.length > 0
+      ? [...existingSubreddits, ...extractSearchTerms(body.name, body.description, body.audience).slice(0, 5)]
+      : extractSearchTerms(body.name, body.description, body.audience);
+
+    const searchResults = await Promise.all(
+      searchTerms.map((term) => searchRedditSubreddits(term))
+    );
+
+    // Dedupe all results and exclude user's existing picks
+    const existingNames = new Set(existingSubreddits.map((n) => n.toLowerCase()));
+    const seen = new Set<string>();
+    const allResults = searchResults
+      .flat()
+      .filter((s) => {
+        const key = s.name.toLowerCase();
+        if (seen.has(key)) return false;
+        if (existingNames.has(key)) return false;
+        seen.add(key);
+        return s.subscribers >= 1000;
+      });
+
+    // Split into size buckets to ensure a mix of large, medium, and niche subreddits
+    const large = allResults.filter((s) => s.subscribers >= 100000).sort((a, b) => b.subscribers - a.subscribers);
+    const medium = allResults.filter((s) => s.subscribers >= 5000 && s.subscribers < 100000).sort((a, b) => b.subscribers - a.subscribers);
+    const niche = allResults.filter((s) => s.subscribers >= 1000 && s.subscribers < 5000).sort((a, b) => b.subscribers - a.subscribers);
+
+    // Take a balanced mix: up to 6 large, 8 medium, all niche (these are the most valuable)
+    const discoveredSubreddits = [
+      ...niche,
+      ...medium.slice(0, 8),
+      ...large.slice(0, 6),
+    ].slice(0, 25);
+
+    // Step 2: Ask Claude — feed it the real subreddits so it can pick the best ones + add its own
     const client = getAnthropicClient();
-    const prompt = buildSuggestSubredditsPrompt({
-      name: body.name,
-      description: body.description,
-      url: body.url,
-      audience: body.audience,
-      tone: body.tone || 'Professional',
-    });
+    const prompt = buildSuggestSubredditsPrompt(
+      {
+        name: body.name,
+        description: body.description,
+        url: body.url,
+        audience: body.audience,
+        tone: body.tone || 'Professional',
+      },
+      discoveredSubreddits,
+      existingSubreddits
+    );
 
     const message = await client.messages.create({
       model: AI_MODEL,
@@ -40,6 +157,69 @@ export async function POST(request: NextRequest) {
     }
 
     const parsed = JSON.parse(responseText);
+
+    // Step 3: Verify AI-suggested subreddits actually exist on Reddit
+    if (parsed.subreddits?.length) {
+      const discoveredNames = new Set(discoveredSubreddits.map((s) => s.name.toLowerCase()));
+      const toVerify = parsed.subreddits.filter(
+        (s: { name: string }) => !discoveredNames.has(s.name.toLowerCase())
+      );
+
+      const verifications = await Promise.all(
+        toVerify.map(async (s: { name: string }) => ({
+          name: s.name,
+          exists: await verifySubredditExists(s.name),
+        }))
+      );
+
+      const nonExistent = new Set(
+        verifications.filter((v) => !v.exists).map((v) => v.name.toLowerCase())
+      );
+
+      parsed.subreddits = parsed.subreddits.filter(
+        (s: { name: string }) => !nonExistent.has(s.name.toLowerCase())
+      );
+    }
+
+    // Step 4: Auto-include discovered subreddits that strongly match the target audience
+    // This catches subreddits Claude overlooked despite obvious keyword matches
+    if (body.audience && parsed.subreddits?.length) {
+      const audienceKeywords = body.audience
+        .toLowerCase()
+        .split(/[\s,]+/)
+        .filter((w: string) => w.length > 2);
+
+      const aiSuggestedNames = new Set(
+        parsed.subreddits.map((s: { name: string }) => s.name.toLowerCase())
+      );
+
+      for (const sub of discoveredSubreddits) {
+        if (aiSuggestedNames.has(sub.name.toLowerCase())) continue;
+
+        // Check if the subreddit's name or description contains audience keywords
+        const text = `${sub.name} ${sub.description}`.toLowerCase();
+        const matchCount = audienceKeywords.filter((kw: string) => text.includes(kw)).length;
+        const matchRatio = matchCount / audienceKeywords.length;
+
+        // If more than 40% of audience keywords appear in the subreddit, auto-include it
+        if (matchRatio >= 0.4 && matchCount >= 2) {
+          parsed.subreddits.push({
+            name: sub.name,
+            reason: sub.description || `Matches your target audience keywords`,
+            approach: 'This subreddit closely matches your target audience.',
+            match: 'best',
+          });
+        }
+      }
+    }
+
+    // Step 5: Filter out user's existing subreddits from final results (in case Claude included them)
+    if (existingSubreddits.length > 0 && parsed.subreddits?.length) {
+      parsed.subreddits = parsed.subreddits.filter(
+        (s: { name: string }) => !existingNames.has(s.name.toLowerCase())
+      );
+    }
+
     return NextResponse.json(parsed);
   } catch (error) {
     console.error('AI suggest-subreddits error:', error);

--- a/app/src/app/api/github/analyze-repo/route.ts
+++ b/app/src/app/api/github/analyze-repo/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAnthropicClient, AI_MODEL } from '@/lib/ai/client';
+
+function parseRepoUrl(url: string): { owner: string; repo: string } | null {
+  // Handle: https://github.com/owner/repo, github.com/owner/repo, owner/repo
+  const cleaned = url.trim().replace(/\/+$/, '');
+  const ghMatch = cleaned.match(/(?:github\.com\/)?([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (ghMatch) return { owner: ghMatch[1], repo: ghMatch[2] };
+  return null;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { repoUrl } = await request.json();
+    if (!repoUrl) {
+      return NextResponse.json({ error: 'Repository URL is required' }, { status: 400 });
+    }
+
+    const parsed = parseRepoUrl(repoUrl);
+    if (!parsed) {
+      return NextResponse.json({ error: 'Invalid GitHub repository URL' }, { status: 400 });
+    }
+
+    const { owner, repo } = parsed;
+
+    // Fetch repo metadata + README in parallel
+    const [repoRes, readmeRes] = await Promise.all([
+      fetch(`https://api.github.com/repos/${owner}/${repo}`, {
+        headers: { Accept: 'application/vnd.github.v3+json', 'User-Agent': 'SuperReddit' },
+      }),
+      fetch(`https://api.github.com/repos/${owner}/${repo}/readme`, {
+        headers: { Accept: 'application/vnd.github.v3+json', 'User-Agent': 'SuperReddit' },
+      }),
+    ]);
+
+    if (!repoRes.ok) {
+      return NextResponse.json(
+        { error: 'Repository not found. Make sure it\u2019s a public repo.' },
+        { status: 404 }
+      );
+    }
+
+    const repoData = await repoRes.json();
+
+    let readmeContent = '';
+    if (readmeRes.ok) {
+      const readmeData = await readmeRes.json();
+      if (readmeData.content) {
+        readmeContent = Buffer.from(readmeData.content, 'base64').toString('utf-8');
+        // Truncate very long READMEs
+        if (readmeContent.length > 8000) {
+          readmeContent = readmeContent.slice(0, 8000) + '\n\n[README truncated]';
+        }
+      }
+    }
+
+    // Build context for Claude
+    const repoContext = [
+      `Repository: ${repoData.full_name}`,
+      repoData.description ? `Description: ${repoData.description}` : '',
+      repoData.homepage ? `Homepage: ${repoData.homepage}` : '',
+      `Language: ${repoData.language || 'Unknown'}`,
+      `Stars: ${repoData.stargazers_count}`,
+      repoData.topics?.length ? `Topics: ${repoData.topics.join(', ')}` : '',
+      readmeContent ? `\n## README\n${readmeContent}` : '',
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    const client = getAnthropicClient();
+    const message = await client.messages.create({
+      model: AI_MODEL,
+      max_tokens: 1024,
+      system: `You analyze GitHub repositories and extract product information for marketing purposes. You MUST base your description strictly on what the README and repo metadata explicitly state. Never generalize, assume, or add categories, markets, or features that are not specifically mentioned in the source material. Always respond in valid JSON.`,
+      messages: [
+        {
+          role: 'user',
+          content: `Analyze this GitHub repository and extract product information I can use for Reddit marketing.
+
+${repoContext}
+
+IMPORTANT: Only describe what is explicitly stated in the README and repo metadata. Do not generalize or broaden the scope. If the README says the product is for one specific market, category, or use case, only mention that one — do not list adjacent or similar markets.
+
+Return JSON with these fields:
+{
+  "productName": "The product/project name (human-friendly, not the repo slug)",
+  "productDescription": "A 2-3 sentence description of what this product does and who it's for. Only include details that are explicitly mentioned in the README. Do not infer or add features, markets, or categories beyond what is stated.",
+  "productUrl": "The best URL for the product (homepage if available, otherwise the GitHub URL)"
+}`,
+        },
+      ],
+    });
+
+    const textContent = message.content.find((c) => c.type === 'text');
+    if (!textContent || textContent.type !== 'text') {
+      return NextResponse.json({ error: 'No response from AI' }, { status: 500 });
+    }
+
+    let responseText = textContent.text.trim();
+    if (responseText.startsWith('```')) {
+      responseText = responseText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+    }
+
+    const result = JSON.parse(responseText);
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('GitHub analyze error:', error);
+    return NextResponse.json(
+      { error: 'Failed to analyze repository. Please try again.' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/src/app/api/reddit/search-subreddits/route.ts
+++ b/app/src/app/api/reddit/search-subreddits/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const REDDIT_BASE = 'https://www.reddit.com';
+const USER_AGENT = 'web:superreddit:v1.0.0 (by /u/superreddit_app)';
+
+export async function GET(request: NextRequest) {
+  const query = request.nextUrl.searchParams.get('q');
+  if (!query || query.length < 2) {
+    return NextResponse.json({ subreddits: [] });
+  }
+
+  try {
+    const res = await fetch(
+      `${REDDIT_BASE}/subreddits/search.json?q=${encodeURIComponent(query)}&limit=8&raw_json=1`,
+      {
+        headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+      }
+    );
+
+    if (!res.ok) {
+      return NextResponse.json({ subreddits: [] });
+    }
+
+    const json = (await res.json()) as {
+      data: { children: Array<{ data: Record<string, unknown> }> };
+    };
+
+    const subreddits = json.data.children.map((c) => ({
+      name: c.data.display_name as string,
+      subscribers: (c.data.subscribers as number) || 0,
+      description: ((c.data.public_description as string) || '').slice(0, 120),
+    }));
+
+    return NextResponse.json({ subreddits });
+  } catch {
+    return NextResponse.json({ subreddits: [] });
+  }
+}

--- a/app/src/app/auth/callback/route.ts
+++ b/app/src/app/auth/callback/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get('code');
+  const next = searchParams.get('next') ?? '/projects';
+
+  if (code) {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+  }
+
+  // If there's no code or exchange failed, redirect to login
+  return NextResponse.redirect(`${origin}/login`);
+}

--- a/app/src/app/onboarding/page.tsx
+++ b/app/src/app/onboarding/page.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { AnimatePresence, motion } from 'motion/react';
+import { createClient } from '@/lib/supabase/client';
+import { Toaster } from '@/components/ui/sonner';
+import { toast } from 'sonner';
+import {
+  OnboardingSidebar,
+  WelcomeStep,
+  ProductStep,
+  SubredditsStep,
+  ToneStep,
+  CompletionStep,
+} from '@/components/onboarding';
+import type { AddedSubreddit } from '@/components/onboarding';
+import type { SuggestedSubreddit } from '@/lib/ai/prompts';
+import { slideHorizontalVariants } from '@/lib/motion';
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const supabase = createClient();
+
+  const [step, setStep] = useState(0);
+  const directionRef = useRef(1);
+  const [userName, setUserName] = useState('');
+  const [finishing, setFinishing] = useState(false);
+
+  // Product fields
+  const [productName, setProductName] = useState('');
+  const [productDescription, setProductDescription] = useState('');
+  const [productUrl, setProductUrl] = useState('');
+  const [targetAudience, setTargetAudience] = useState('');
+
+  // Subreddits (lifted from SubredditsStep for persistence)
+  const [addedSubreddits, setAddedSubreddits] = useState<AddedSubreddit[]>([]);
+  const [aiSuggestions, setAiSuggestions] = useState<SuggestedSubreddit[]>([]);
+  const [aiFetched, setAiFetched] = useState(false);
+  const selectedSubreddits = new Set(addedSubreddits.map((s) => s.name));
+
+  // Writing style
+  const [likedStyles, setLikedStyles] = useState<Set<string>>(new Set());
+  const [toneCompleted, setToneCompleted] = useState(false);
+  const tone = 'Adaptive'; // Derived from liked styles at generation time
+
+  useEffect(() => {
+    loadUser();
+  }, []);
+
+  async function loadUser() {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      router.replace('/login');
+      return;
+    }
+    setUserName(user.user_metadata?.full_name || user.email || '');
+  }
+
+  function goToStep(next: number) {
+    directionRef.current = next > step ? 1 : -1;
+    setStep(next);
+  }
+
+  async function handleFinish() {
+    setFinishing(true);
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) {
+        toast.error('Not authenticated');
+        setFinishing(false);
+        return;
+      }
+
+      // 1. Create the project
+      const writingStylesArray = Array.from(likedStyles);
+      const { data: project, error: projectError } = await supabase
+        .from('projects')
+        .insert({
+          user_id: user.id,
+          name: `${productName} Campaign`,
+          product_name: productName,
+          product_description: productDescription,
+          product_url: productUrl || null,
+          target_audience: targetAudience || null,
+          tone,
+          writing_styles: writingStylesArray,
+        })
+        .select()
+        .single();
+
+      if (projectError || !project) {
+        toast.error('Failed to create project');
+        setFinishing(false);
+        return;
+      }
+
+      // 2. Build canvas state with product node + subreddit nodes + edges
+      const productNodeId = 'product-node';
+      const subsArray = Array.from(selectedSubreddits);
+
+      const nodes = [
+        {
+          id: productNodeId,
+          type: 'product',
+          position: { x: 0, y: Math.max(0, (subsArray.length * 420 - 300) / 2) },
+          data: {
+            type: 'product',
+            name: productName,
+            description: productDescription,
+            url: productUrl || '',
+            audience: targetAudience || '',
+            tone,
+            writingStyles: writingStylesArray,
+          },
+        },
+        ...subsArray.map((subName, i) => ({
+          id: `subreddit-${subName}`,
+          type: 'subreddit',
+          position: { x: 420, y: i * 420 },
+          data: {
+            type: 'subreddit',
+            name: subName,
+            subscribers: null,
+            description: null,
+            posts: [],
+            loading: false,
+            sortBy: 'hot',
+          },
+        })),
+      ];
+
+      const edges = subsArray.map((subName) => ({
+        id: `e-${productNodeId}-subreddit-${subName}`,
+        source: productNodeId,
+        target: `subreddit-${subName}`,
+        animated: true,
+      }));
+
+      // 3. Save canvas state
+      const { error: canvasError } = await supabase.from('canvas_states').insert({
+        project_id: project.id,
+        nodes,
+        edges,
+        viewport: { x: 0, y: 0, zoom: 0.8 },
+      });
+
+      if (canvasError) {
+        console.error('Canvas save error:', canvasError);
+        // Non-fatal — project was created, canvas will init on load
+      }
+
+      // 4. Add subreddits to the subreddits table
+      if (subsArray.length > 0) {
+        await supabase.from('subreddits').insert(
+          subsArray.map((name) => ({
+            project_id: project.id,
+            name,
+          }))
+        );
+      }
+
+      // 5. Mark onboarding complete
+      const { error: profileError } = await supabase
+        .from('profiles')
+        .update({ onboarding_completed: true })
+        .eq('id', user.id);
+
+      if (profileError) {
+        console.error('Profile update error:', profileError);
+      }
+
+      // 6. Redirect to the new project canvas
+      router.replace(`/projects/${project.id}`);
+    } catch (err) {
+      console.error('Onboarding finish error:', err);
+      toast.error('Something went wrong. Please try again.');
+      setFinishing(false);
+    }
+  }
+
+  return (
+    <div className="flex h-screen bg-background">
+      <OnboardingSidebar currentStep={step} />
+
+      <main className="flex flex-1 items-center justify-center overflow-y-auto p-8">
+        <AnimatePresence mode="wait" custom={directionRef.current}>
+          <motion.div
+            key={step}
+            custom={directionRef.current}
+            variants={slideHorizontalVariants}
+            initial="enter"
+            animate="center"
+            exit="exit"
+            className="w-full max-w-2xl"
+          >
+            {step === 0 && (
+              <WelcomeStep userName={userName} onNext={() => goToStep(1)} />
+            )}
+            {step === 1 && (
+              <ProductStep
+                productName={productName}
+                productDescription={productDescription}
+                productUrl={productUrl}
+                targetAudience={targetAudience}
+                onProductNameChange={setProductName}
+                onProductDescriptionChange={setProductDescription}
+                onProductUrlChange={setProductUrl}
+                onTargetAudienceChange={setTargetAudience}
+                onNext={() => goToStep(2)}
+              />
+            )}
+            {step === 2 && (
+              <SubredditsStep
+                productName={productName}
+                productDescription={productDescription}
+                productUrl={productUrl}
+                targetAudience={targetAudience}
+                tone={tone}
+                addedSubs={addedSubreddits}
+                onAddedSubsChange={setAddedSubreddits}
+                aiSuggestions={aiSuggestions}
+                onAiSuggestionsChange={setAiSuggestions}
+                aiFetched={aiFetched}
+                onAiFetchedChange={setAiFetched}
+                onBack={() => goToStep(1)}
+                onNext={() => goToStep(3)}
+              />
+            )}
+            {step === 3 && (
+              <ToneStep
+                likedStyles={likedStyles}
+                onLikedStylesChange={setLikedStyles}
+                completed={toneCompleted}
+                onComplete={() => setToneCompleted(true)}
+                onReset={() => {
+                  setToneCompleted(false);
+                  setLikedStyles(new Set());
+                }}
+                onBack={() => goToStep(2)}
+                onNext={() => goToStep(4)}
+              />
+            )}
+            {step === 4 && (
+              <CompletionStep
+                userName={userName}
+                productName={productName}
+                selectedSubreddits={selectedSubreddits}
+                likedStyles={likedStyles}
+                loading={finishing}
+                onBack={() => goToStep(3)}
+                onFinish={handleFinish}
+              />
+            )}
+          </motion.div>
+        </AnimatePresence>
+      </main>
+
+      <Toaster />
+    </div>
+  );
+}

--- a/app/src/components/canvas/OnboardingWizard.tsx
+++ b/app/src/components/canvas/OnboardingWizard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef } from 'react';
-import { ArrowRight, ArrowLeft, Sparkles, Loader2, CheckCircle2, AlertTriangle, Shield, Check } from 'lucide-react';
+import { ArrowRight, ArrowLeft, Sparkles, Loader2, AlertTriangle, Check } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -67,10 +67,10 @@ export function OnboardingWizard({ project, onComplete }: OnboardingWizardProps)
       const json = await res.json();
       if (json.subreddits) {
         setSuggestions(json.subreddits);
-        // Auto-select low-risk ones
+        // Auto-select best matches
         const autoSelect = new Set<string>();
         json.subreddits.forEach((s: SuggestedSubreddit) => {
-          if (s.risk === 'low') autoSelect.add(s.name);
+          if (s.match === 'best') autoSelect.add(s.name);
         });
         setSelectedSubs(autoSelect);
       }
@@ -86,7 +86,7 @@ export function OnboardingWizard({ project, onComplete }: OnboardingWizardProps)
     setSelectedSubs((prev) => new Set(prev).add(name));
     // Also add as a suggestion card for display
     if (!suggestions.find((s) => s.name === name)) {
-      setSuggestions((prev) => [...prev, { name, reason: 'Manually added', approach: '', risk: 'medium' as const }]);
+      setSuggestions((prev) => [...prev, { name, reason: 'Manually added', approach: '', match: 'relevant' as const }]);
     }
     setManualInput('');
   }
@@ -153,16 +153,16 @@ export function OnboardingWizard({ project, onComplete }: OnboardingWizardProps)
     onComplete();
   }
 
-  const riskColors = {
-    low: 'bg-green-500/10 text-green-600 border-green-500/20',
-    medium: 'bg-yellow-500/10 text-yellow-600 border-yellow-500/20',
-    high: 'bg-red-500/10 text-red-600 border-red-500/20',
+  const matchColors = {
+    best: 'bg-green-500/10 text-green-600 border-green-500/20',
+    good: 'bg-blue-500/10 text-blue-600 border-blue-500/20',
+    relevant: 'bg-muted text-muted-foreground border-border',
   };
 
-  const riskIcons = {
-    low: <CheckCircle2 className="h-3.5 w-3.5" />,
-    medium: <AlertTriangle className="h-3.5 w-3.5" />,
-    high: <Shield className="h-3.5 w-3.5" />,
+  const matchLabels = {
+    best: 'Best match',
+    good: 'Good match',
+    relevant: 'Relevant',
   };
 
   return (
@@ -320,9 +320,8 @@ export function OnboardingWizard({ project, onComplete }: OnboardingWizardProps)
                                 <div className="flex-1 min-w-0">
                                   <div className="flex items-center gap-2">
                                     <span className="font-medium text-sm">r/{sub.name}</span>
-                                    <Badge variant="outline" className={`text-[10px] h-5 gap-1 ${riskColors[sub.risk]}`}>
-                                      {riskIcons[sub.risk]}
-                                      {sub.risk} risk
+                                    <Badge variant="outline" className={`text-[10px] h-5 ${matchColors[sub.match]}`}>
+                                      {matchLabels[sub.match]}
                                     </Badge>
                                   </div>
                                   <p className="text-xs text-muted-foreground mt-1">{sub.reason}</p>

--- a/app/src/components/canvas/panels/CanvasToolbar.tsx
+++ b/app/src/components/canvas/panels/CanvasToolbar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Plus, Sparkles, Loader2, FileText, Bookmark, AlertTriangle, ShieldCheck, ShieldAlert } from 'lucide-react';
+import { Plus, Sparkles, Loader2, FileText, Bookmark } from 'lucide-react';
 import { useCanvasStore } from '@/stores/canvas-store';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -189,6 +189,7 @@ export function CanvasToolbar({ project, onToggleDrafts, draftsOpen, onToggleBoo
             url: productNode.data.url || undefined,
             audience: productNode.data.audience || undefined,
             tone: productNode.data.tone,
+            writingStyles: (productNode.data as ProductNodeData).writingStyles || project.writing_styles || [],
           },
           examplePosts: selectedPosts.map((p) => ({
             title: (p.data as ExamplePostNodeData).title,
@@ -302,15 +303,12 @@ export function CanvasToolbar({ project, onToggleDrafts, draftsOpen, onToggleBoo
                       >
                         <div className="flex items-center justify-between">
                           <span className="text-sm font-medium">r/{s.name}</span>
-                          <span className={`flex items-center gap-1 text-[10px] font-medium rounded-full px-2 py-0.5 ${
-                            s.risk === 'low' ? 'bg-green-500/10 text-green-500' :
-                            s.risk === 'medium' ? 'bg-yellow-500/10 text-yellow-500' :
-                            'bg-red-500/10 text-red-500'
+                          <span className={`text-[10px] font-medium rounded-full px-2 py-0.5 ${
+                            s.match === 'best' ? 'bg-green-500/10 text-green-500' :
+                            s.match === 'good' ? 'bg-blue-500/10 text-blue-500' :
+                            'bg-muted text-muted-foreground'
                           }`}>
-                            {s.risk === 'low' ? <ShieldCheck className="h-2.5 w-2.5" /> :
-                             s.risk === 'medium' ? <ShieldAlert className="h-2.5 w-2.5" /> :
-                             <AlertTriangle className="h-2.5 w-2.5" />}
-                            {s.risk}
+                            {s.match === 'best' ? 'Best match' : s.match === 'good' ? 'Good match' : 'Relevant'}
                           </span>
                         </div>
                         <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{s.reason}</p>

--- a/app/src/components/onboarding/OnboardingSidebar.tsx
+++ b/app/src/components/onboarding/OnboardingSidebar.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { Check } from 'lucide-react';
+import { motion } from 'motion/react';
+
+const STEPS = [
+  { label: 'Welcome' },
+  { label: 'Your Product' },
+  { label: 'Subreddits' },
+  { label: 'Writing DNA' },
+  { label: 'All Set' },
+];
+
+interface OnboardingSidebarProps {
+  currentStep: number;
+}
+
+export function OnboardingSidebar({ currentStep }: OnboardingSidebarProps) {
+  return (
+    <div className="flex w-60 flex-col justify-between border-r bg-card p-8">
+      <div>
+        <div className="mb-10 flex items-center gap-2">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-orange-500 text-white font-bold text-sm">
+            SR
+          </div>
+          <span className="font-semibold">SuperReddit</span>
+        </div>
+
+        <nav className="space-y-1">
+          {STEPS.map((step, i) => {
+            const isCompleted = i < currentStep;
+            const isCurrent = i === currentStep;
+
+            return (
+              <div key={step.label} className="flex items-center gap-3 py-2.5">
+                <div className="relative flex h-7 w-7 shrink-0 items-center justify-center">
+                  {isCompleted ? (
+                    <motion.div
+                      initial={{ scale: 0.8 }}
+                      animate={{ scale: 1 }}
+                      className="flex h-7 w-7 items-center justify-center rounded-full bg-orange-500 text-white"
+                    >
+                      <Check className="h-3.5 w-3.5" />
+                    </motion.div>
+                  ) : (
+                    <div
+                      className={`h-7 w-7 rounded-full border-2 transition-colors ${
+                        isCurrent
+                          ? 'border-orange-500 bg-orange-500/10'
+                          : 'border-muted-foreground/20'
+                      }`}
+                    >
+                      {isCurrent && (
+                        <motion.div
+                          layoutId="step-dot"
+                          className="absolute inset-[6px] rounded-full bg-orange-500"
+                        />
+                      )}
+                    </div>
+                  )}
+                </div>
+                <span
+                  className={`text-sm transition-colors ${
+                    isCurrent
+                      ? 'font-medium text-foreground'
+                      : isCompleted
+                        ? 'text-muted-foreground'
+                        : 'text-muted-foreground/50'
+                  }`}
+                >
+                  {step.label}
+                </span>
+              </div>
+            );
+          })}
+        </nav>
+      </div>
+
+      <p className="text-xs text-muted-foreground/50">
+        You can always change these settings later.
+      </p>
+    </div>
+  );
+}

--- a/app/src/components/onboarding/index.ts
+++ b/app/src/components/onboarding/index.ts
@@ -1,0 +1,7 @@
+export { OnboardingSidebar } from './OnboardingSidebar';
+export { WelcomeStep } from './steps/WelcomeStep';
+export { ProductStep } from './steps/ProductStep';
+export { SubredditsStep } from './steps/SubredditsStep';
+export type { AddedSubreddit } from './steps/SubredditsStep';
+export { ToneStep } from './steps/ToneStep';
+export { CompletionStep } from './steps/CompletionStep';

--- a/app/src/components/onboarding/steps/CompletionStep.tsx
+++ b/app/src/components/onboarding/steps/CompletionStep.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { ArrowLeft, Loader2, Megaphone, Target, TrendingUp } from 'lucide-react';
+import { motion } from 'motion/react';
+import { Button } from '@/components/ui/button';
+
+interface CompletionStepProps {
+  userName: string;
+  productName: string;
+  selectedSubreddits: Set<string>;
+  likedStyles: Set<string>;
+  loading: boolean;
+  onBack: () => void;
+  onFinish: () => void;
+}
+
+export function CompletionStep({
+  userName,
+  productName,
+  selectedSubreddits,
+  likedStyles,
+  loading,
+  onBack,
+  onFinish,
+}: CompletionStepProps) {
+  const firstName = userName.split(' ')[0] || userName;
+
+  return (
+    <div className="w-full max-w-lg mx-auto text-center">
+      {/* Avatar */}
+      <motion.div
+        initial={{ scale: 0.5, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ duration: 0.4, ease: [0.25, 0.1, 0.25, 1] }}
+        className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-orange-500 text-white text-2xl font-bold"
+      >
+        {firstName.charAt(0).toUpperCase()}
+      </motion.div>
+
+      <motion.div
+        initial={{ y: 10, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ delay: 0.15, duration: 0.4 }}
+      >
+        <h2 className="text-2xl font-bold tracking-tight">
+          Hey {firstName}!
+        </h2>
+      </motion.div>
+
+      <motion.div
+        initial={{ y: 10, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ delay: 0.25, duration: 0.4 }}
+        className="mt-3 space-y-3"
+      >
+        <p className="text-base text-muted-foreground leading-relaxed">
+          You&apos;re all set up and ready to grow. This is just the beginning of
+          your journey to reaching the right people on Reddit.
+        </p>
+      </motion.div>
+
+      {/* Stats / what they set up */}
+      <motion.div
+        initial={{ y: 15, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ delay: 0.4, duration: 0.4 }}
+        className="mt-8 grid grid-cols-3 gap-3"
+      >
+        <div className="rounded-xl border bg-card p-4">
+          <div className="mx-auto mb-2 flex h-9 w-9 items-center justify-center rounded-lg bg-orange-500/10">
+            <Megaphone className="h-4.5 w-4.5 text-orange-500" />
+          </div>
+          <p className="text-2xl font-bold">{selectedSubreddits.size}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {selectedSubreddits.size === 1 ? 'Subreddit' : 'Subreddits'}
+          </p>
+        </div>
+
+        <div className="rounded-xl border bg-card p-4">
+          <div className="mx-auto mb-2 flex h-9 w-9 items-center justify-center rounded-lg bg-purple-500/10">
+            <Target className="h-4.5 w-4.5 text-purple-500" />
+          </div>
+          <p className="text-2xl font-bold">{likedStyles.size}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Writing {likedStyles.size === 1 ? 'Style' : 'Styles'}
+          </p>
+        </div>
+
+        <div className="rounded-xl border bg-card p-4">
+          <div className="mx-auto mb-2 flex h-9 w-9 items-center justify-center rounded-lg bg-green-500/10">
+            <TrendingUp className="h-4.5 w-4.5 text-green-500" />
+          </div>
+          <p className="text-2xl font-bold">AI</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Powered Posts
+          </p>
+        </div>
+      </motion.div>
+
+      <motion.p
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.55, duration: 0.4 }}
+        className="mt-6 text-sm text-muted-foreground"
+      >
+        We&apos;ll help you craft authentic posts for <span className="font-medium text-foreground">{productName}</span> that
+        blend into each community naturally.
+      </motion.p>
+
+      {/* CTA */}
+      <motion.div
+        initial={{ y: 10, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ delay: 0.65, duration: 0.4 }}
+        className="mt-8"
+      >
+        <Button
+          onClick={onFinish}
+          size="lg"
+          disabled={loading}
+          className="w-full h-12 text-base bg-orange-500 hover:bg-orange-600 text-white rounded-xl"
+        >
+          {loading ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : null}
+          Start Growing on Reddit
+        </Button>
+      </motion.div>
+
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.75, duration: 0.3 }}
+        className="mt-4"
+      >
+        <Button variant="ghost" size="sm" onClick={onBack} disabled={loading} className="text-xs text-muted-foreground">
+          <ArrowLeft className="mr-1.5 h-3.5 w-3.5" /> Go back
+        </Button>
+      </motion.div>
+    </div>
+  );
+}

--- a/app/src/components/onboarding/steps/ProductStep.tsx
+++ b/app/src/components/onboarding/steps/ProductStep.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import { useState } from 'react';
+import { ArrowRight, Check, Github, Loader2, Pencil, Sparkles, X } from 'lucide-react';
+import { motion, AnimatePresence } from 'motion/react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { scaleFadeVariants } from '@/lib/motion';
+
+interface AnalysisResult {
+  productName: string;
+  productDescription: string;
+  productUrl: string;
+  targetAudience: string;
+}
+
+interface ProductStepProps {
+  productName: string;
+  productDescription: string;
+  productUrl: string;
+  targetAudience: string;
+  onProductNameChange: (v: string) => void;
+  onProductDescriptionChange: (v: string) => void;
+  onProductUrlChange: (v: string) => void;
+  onTargetAudienceChange: (v: string) => void;
+  onNext: () => void;
+}
+
+export function ProductStep({
+  productName,
+  productDescription,
+  productUrl,
+  targetAudience,
+  onProductNameChange,
+  onProductDescriptionChange,
+  onProductUrlChange,
+  onTargetAudienceChange,
+  onNext,
+}: ProductStepProps) {
+  const [repoUrl, setRepoUrl] = useState('');
+  const [analyzing, setAnalyzing] = useState(false);
+  const [analyzeError, setAnalyzeError] = useState('');
+  const [suggestion, setSuggestion] = useState<AnalysisResult | null>(null);
+  const [editingSuggestion, setEditingSuggestion] = useState(false);
+  const [editedDescription, setEditedDescription] = useState('');
+
+  const canContinue = productName.trim() && productDescription.trim() && targetAudience.trim();
+
+  async function handleAnalyzeRepo() {
+    if (!repoUrl.trim()) return;
+    setAnalyzing(true);
+    setAnalyzeError('');
+    setSuggestion(null);
+    try {
+      const res = await fetch('/api/github/analyze-repo', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ repoUrl }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setAnalyzeError(data.error || 'Failed to analyze repo');
+        setAnalyzing(false);
+        return;
+      }
+      // Auto-fill name and URL immediately — description goes to review
+      if (data.productName) onProductNameChange(data.productName);
+      if (data.productUrl) onProductUrlChange(data.productUrl);
+      setSuggestion(data);
+      setEditedDescription(data.productDescription || '');
+    } catch {
+      setAnalyzeError('Failed to analyze repo. Please try again.');
+    }
+    setAnalyzing(false);
+  }
+
+  function handleAccept() {
+    if (suggestion) {
+      onProductDescriptionChange(suggestion.productDescription);
+    }
+    setSuggestion(null);
+    setEditingSuggestion(false);
+  }
+
+  function handleAcceptEdited() {
+    onProductDescriptionChange(editedDescription);
+    setSuggestion(null);
+    setEditingSuggestion(false);
+  }
+
+  function handleDeny() {
+    setSuggestion(null);
+    setEditingSuggestion(false);
+  }
+
+  return (
+    <div className="w-full max-w-lg mx-auto">
+      <h2 className="text-2xl font-bold tracking-tight">Your Product</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Tell us about what you&apos;re promoting. The AI uses this to find the right communities.
+      </p>
+
+      {/* GitHub import */}
+      <div className="mt-6 rounded-xl border bg-card p-4">
+        <div className="flex items-center gap-2 mb-2">
+          <Github className="h-4 w-4" />
+          <span className="text-sm font-medium">Import from GitHub</span>
+        </div>
+        <p className="text-xs text-muted-foreground mb-3">
+          Paste a public repo link and we&apos;ll analyze it to auto-fill your product details.
+        </p>
+        <div className="flex gap-2">
+          <Input
+            value={repoUrl}
+            onChange={(e) => { setRepoUrl(e.target.value); setAnalyzeError(''); }}
+            onKeyDown={(e) => e.key === 'Enter' && handleAnalyzeRepo()}
+            placeholder="https://github.com/owner/repo"
+            className="text-sm"
+            disabled={analyzing}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleAnalyzeRepo}
+            disabled={!repoUrl.trim() || analyzing}
+            className="shrink-0"
+          >
+            {analyzing ? (
+              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Sparkles className="mr-1.5 h-3.5 w-3.5" />
+            )}
+            {analyzing ? 'Analyzing...' : 'Analyze'}
+          </Button>
+        </div>
+        {analyzeError && (
+          <p className="mt-2 text-xs text-destructive">{analyzeError}</p>
+        )}
+      </div>
+
+      {/* AI suggestion review card */}
+      <AnimatePresence>
+        {suggestion && (
+          <motion.div
+            variants={scaleFadeVariants}
+            initial="hidden"
+            animate="visible"
+            exit="exit"
+            className="mt-4 rounded-xl border border-orange-500/30 bg-orange-500/5 p-4"
+          >
+            <div className="flex items-center gap-2 mb-2">
+              <Sparkles className="h-4 w-4 text-orange-500" />
+              <span className="text-sm font-medium">AI-Generated Description</span>
+            </div>
+
+            {editingSuggestion ? (
+              <>
+                <Textarea
+                  value={editedDescription}
+                  onChange={(e) => setEditedDescription(e.target.value)}
+                  rows={4}
+                  className="mt-1 text-sm bg-background"
+                />
+                <div className="mt-3 flex gap-2">
+                  <Button size="sm" onClick={handleAcceptEdited} disabled={!editedDescription.trim()}>
+                    <Check className="mr-1.5 h-3.5 w-3.5" /> Save
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={() => setEditingSuggestion(false)}>
+                    Cancel
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  {suggestion.productDescription}
+                </p>
+                <div className="mt-3 flex gap-2">
+                  <Button size="sm" onClick={handleAccept}>
+                    <Check className="mr-1.5 h-3.5 w-3.5" /> Accept
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={() => setEditingSuggestion(true)}>
+                    <Pencil className="mr-1.5 h-3.5 w-3.5" /> Edit
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={handleDeny}>
+                    <X className="mr-1.5 h-3.5 w-3.5" /> Dismiss
+                  </Button>
+                </div>
+              </>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <div className="relative my-5 flex items-center">
+        <div className="flex-1 border-t" />
+        <span className="px-3 text-xs text-muted-foreground">or fill in manually</span>
+        <div className="flex-1 border-t" />
+      </div>
+
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="ob-product-name" className="text-xs">
+              Product Name <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="ob-product-name"
+              value={productName}
+              onChange={(e) => onProductNameChange(e.target.value)}
+              placeholder="My SaaS"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="ob-product-url" className="text-xs">
+              URL (optional)
+            </Label>
+            <Input
+              id="ob-product-url"
+              value={productUrl}
+              onChange={(e) => onProductUrlChange(e.target.value)}
+              placeholder="https://yourproduct.com"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="ob-product-desc" className="text-xs">
+            What does it do? <span className="text-destructive">*</span>
+          </Label>
+          <Textarea
+            id="ob-product-desc"
+            value={productDescription}
+            onChange={(e) => onProductDescriptionChange(e.target.value)}
+            placeholder="Describe your product in 2-3 sentences..."
+            rows={3}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="ob-audience" className="text-xs">
+            Target Audience <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            id="ob-audience"
+            value={targetAudience}
+            onChange={(e) => onTargetAudienceChange(e.target.value)}
+            placeholder="Indie hackers, SaaS founders, developers..."
+          />
+        </div>
+      </div>
+
+      <div className="mt-8 flex justify-end">
+        <Button onClick={onNext} disabled={!canContinue}>
+          Continue <ArrowRight className="ml-2 h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/onboarding/steps/SubredditsStep.tsx
+++ b/app/src/components/onboarding/steps/SubredditsStep.tsx
@@ -1,0 +1,400 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { ArrowLeft, ArrowRight, AlertTriangle, Loader2, Search, Sparkles, Users, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import type { SuggestedSubreddit } from '@/lib/ai/prompts';
+
+interface SearchResult {
+  name: string;
+  subscribers: number;
+  description: string;
+}
+
+export interface AddedSubreddit {
+  name: string;
+  subscribers?: number;
+  description?: string;
+  match?: 'best' | 'good' | 'relevant';
+  fromAI?: boolean;
+  reason?: string;
+  approach?: string;
+}
+
+interface SubredditsStepProps {
+  productName: string;
+  productDescription: string;
+  productUrl: string;
+  targetAudience: string;
+  tone: string;
+  addedSubs: AddedSubreddit[];
+  onAddedSubsChange: (subs: AddedSubreddit[]) => void;
+  aiSuggestions: SuggestedSubreddit[];
+  onAiSuggestionsChange: (suggestions: SuggestedSubreddit[]) => void;
+  aiFetched: boolean;
+  onAiFetchedChange: (fetched: boolean) => void;
+  onBack: () => void;
+  onNext: () => void;
+}
+
+const matchColors = {
+  best: 'bg-green-500/10 text-green-600 border-green-500/20',
+  good: 'bg-blue-500/10 text-blue-600 border-blue-500/20',
+  relevant: 'bg-muted text-muted-foreground border-border',
+};
+
+const matchLabels = {
+  best: 'Best match',
+  good: 'Good match',
+  relevant: 'Relevant',
+};
+
+function formatSubscribers(n: number): string {
+  if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
+  return n.toString();
+}
+
+export function SubredditsStep({
+  productName,
+  productDescription,
+  productUrl,
+  targetAudience,
+  tone,
+  addedSubs,
+  onAddedSubsChange,
+  aiSuggestions,
+  onAiSuggestionsChange,
+  aiFetched,
+  onAiFetchedChange,
+  onBack,
+  onNext,
+}: SubredditsStepProps) {
+  const [searchInput, setSearchInput] = useState('');
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [showDropdown, setShowDropdown] = useState(false);
+
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiError, setAiError] = useState(false);
+
+  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setShowDropdown(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // Debounced search
+  useEffect(() => {
+    if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
+
+    const query = searchInput.trim().replace(/^r\//, '');
+    if (query.length < 2) {
+      setSearchResults([]);
+      setShowDropdown(false);
+      return;
+    }
+
+    searchTimeoutRef.current = setTimeout(async () => {
+      setSearchLoading(true);
+      try {
+        const res = await fetch(`/api/reddit/search-subreddits?q=${encodeURIComponent(query)}`);
+        const json = await res.json();
+        if (json.subreddits) {
+          setSearchResults(json.subreddits);
+          setShowDropdown(true);
+        }
+      } catch {
+        setSearchResults([]);
+      }
+      setSearchLoading(false);
+    }, 300);
+
+    return () => {
+      if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
+    };
+  }, [searchInput]);
+
+  async function fetchAiSuggestions() {
+    setAiLoading(true);
+    setAiError(false);
+    try {
+      const existingSubreddits = addedSubs.map((s) => s.name);
+      const res = await fetch('/api/ai/suggest-subreddits', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: productName,
+          description: productDescription,
+          url: productUrl || undefined,
+          audience: targetAudience || undefined,
+          tone,
+          existingSubreddits: existingSubreddits.length > 0 ? existingSubreddits : undefined,
+        }),
+      });
+      const json = await res.json();
+      if (json.subreddits) {
+        // Filter out any that are already added
+        const existingNames = new Set(addedSubs.map((s) => s.name.toLowerCase()));
+        const newSuggestions = json.subreddits.filter(
+          (s: SuggestedSubreddit) => !existingNames.has(s.name.toLowerCase())
+        );
+        onAiSuggestionsChange(newSuggestions);
+      }
+    } catch {
+      setAiError(true);
+    }
+    setAiLoading(false);
+    onAiFetchedChange(true);
+  }
+
+  function handleSelectSearchResult(result: SearchResult) {
+    const alreadyExists = addedSubs.some((s) => s.name.toLowerCase() === result.name.toLowerCase());
+    if (alreadyExists) return;
+
+    const newSub: AddedSubreddit = {
+      name: result.name,
+      subscribers: result.subscribers,
+      description: result.description,
+    };
+    onAddedSubsChange([...addedSubs, newSub]);
+
+    setSearchInput('');
+    setShowDropdown(false);
+    setSearchResults([]);
+  }
+
+  function handleAddAiSuggestion(suggestion: SuggestedSubreddit) {
+    const newSub: AddedSubreddit = {
+      name: suggestion.name,
+      match: suggestion.match,
+      fromAI: true,
+      reason: suggestion.reason,
+      approach: suggestion.approach,
+    };
+    onAddedSubsChange([...addedSubs, newSub]);
+
+    // Remove from AI suggestions list
+    onAiSuggestionsChange(aiSuggestions.filter((s) => s.name !== suggestion.name));
+  }
+
+  function handleRemoveSub(name: string) {
+    onAddedSubsChange(addedSubs.filter((s) => s.name !== name));
+  }
+
+  return (
+    <div className="w-full max-w-lg mx-auto">
+      <h2 className="text-2xl font-bold tracking-tight">Choose Subreddits</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Search for subreddits where your target audience hangs out.
+      </p>
+
+      {/* Search input with autocomplete */}
+      <div className="relative mt-4" ref={dropdownRef}>
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            onFocus={() => { if (searchResults.length > 0) setShowDropdown(true); }}
+            placeholder="Search for a subreddit..."
+            className="pl-9 text-sm"
+          />
+          {searchLoading && (
+            <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
+          )}
+        </div>
+
+        {showDropdown && searchResults.length > 0 && (
+          <div className="absolute z-10 mt-1 w-full rounded-xl border bg-card shadow-lg overflow-hidden">
+            {searchResults.map((result) => {
+              const alreadyAdded = addedSubs.some((s) => s.name.toLowerCase() === result.name.toLowerCase());
+              return (
+                <button
+                  key={result.name}
+                  onClick={() => handleSelectSearchResult(result)}
+                  disabled={alreadyAdded}
+                  className={`w-full text-left px-3 py-2.5 transition-colors border-b last:border-b-0 ${
+                    alreadyAdded
+                      ? 'opacity-50 cursor-default'
+                      : 'hover:bg-muted/50 cursor-pointer'
+                  }`}
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-medium">r/{result.name}</span>
+                    <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                      <Users className="h-3 w-3" />
+                      {formatSubscribers(result.subscribers)}
+                    </span>
+                  </div>
+                  {result.description && (
+                    <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">{result.description}</p>
+                  )}
+                  {alreadyAdded && (
+                    <span className="text-[10px] text-orange-500 font-medium">Already added</span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* AI suggestions prompt */}
+      {!aiFetched && !aiLoading && (
+        <button
+          onClick={fetchAiSuggestions}
+          className="mt-2 text-xs text-orange-500 hover:text-orange-400 transition-colors"
+        >
+          <Sparkles className="inline h-3 w-3 mr-1 -mt-0.5" />
+          Stuck? Let AI suggest subreddits for you
+        </button>
+      )}
+
+      {/* Added subreddits list */}
+      <div className="mt-4">
+        {addedSubs.length === 0 && !aiFetched && !aiLoading ? (
+          <div className="flex flex-col items-center justify-center py-12 text-center">
+            <Search className="h-8 w-8 text-muted-foreground/40 mb-3" />
+            <p className="text-sm text-muted-foreground">
+              Search for subreddits above to get started
+            </p>
+            <p className="text-xs text-muted-foreground/70 mt-1">
+              Add the communities where your target audience is most active
+            </p>
+          </div>
+        ) : (
+          <div className="h-72 overflow-y-auto pr-1">
+            <div className="space-y-2">
+              {/* User-added + AI-accepted subreddits */}
+              {addedSubs.map((sub) => (
+                <div
+                  key={sub.name}
+                  className="w-full text-left rounded-xl border border-orange-500 bg-orange-500/5 ring-1 ring-orange-500/20 p-3"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-sm">r/{sub.name}</span>
+                        {sub.subscribers && (
+                          <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                            <Users className="h-2.5 w-2.5" />
+                            {formatSubscribers(sub.subscribers)}
+                          </span>
+                        )}
+                        {sub.match && (
+                          <Badge variant="outline" className={`text-[10px] h-5 ${matchColors[sub.match]}`}>
+                            {matchLabels[sub.match]}
+                          </Badge>
+                        )}
+                      </div>
+                      {sub.description && (
+                        <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{sub.description}</p>
+                      )}
+                      {sub.reason && (
+                        <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{sub.reason}</p>
+                      )}
+                    </div>
+                    <button
+                      onClick={() => handleRemoveSub(sub.name)}
+                      className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                </div>
+              ))}
+
+              {/* AI suggestions section */}
+              {aiLoading && (
+                <div className="flex flex-col items-center justify-center py-8 gap-3">
+                  <Loader2 className="h-6 w-6 animate-spin text-orange-500" />
+                  <p className="text-sm text-muted-foreground">Finding more subreddits...</p>
+                </div>
+              )}
+
+              {aiError && !aiLoading && (
+                <div className="flex flex-col items-center justify-center py-6 gap-2 text-center">
+                  <AlertTriangle className="h-6 w-6 text-yellow-500" />
+                  <p className="text-xs text-muted-foreground">Couldn&apos;t fetch AI suggestions.</p>
+                  <Button variant="outline" size="sm" className="h-7 text-xs" onClick={fetchAiSuggestions}>
+                    Retry
+                  </Button>
+                </div>
+              )}
+
+              {aiFetched && !aiLoading && aiSuggestions.length > 0 && (
+                <>
+                  <div className="flex items-center gap-2 pt-2 pb-1">
+                    <Sparkles className="h-3 w-3 text-orange-500" />
+                    <span className="text-xs font-medium text-muted-foreground">AI Suggestions</span>
+                  </div>
+                  {aiSuggestions.map((sub) => (
+                    <button
+                      key={sub.name}
+                      onClick={() => handleAddAiSuggestion(sub)}
+                      className="w-full text-left rounded-xl border border-border hover:border-muted-foreground/30 p-3 transition-all"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium text-sm">r/{sub.name}</span>
+                            <Badge variant="outline" className={`text-[10px] h-5 ${matchColors[sub.match]}`}>
+                              {matchLabels[sub.match]}
+                            </Badge>
+                          </div>
+                          <p className="text-xs text-muted-foreground mt-1">{sub.reason}</p>
+                          {sub.approach && (
+                            <p className="text-xs text-muted-foreground/70 mt-0.5 italic">{sub.approach}</p>
+                          )}
+                        </div>
+                        <div className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-muted-foreground/30 text-muted-foreground">
+                          <span className="text-xs">+</span>
+                        </div>
+                      </div>
+                    </button>
+                  ))}
+                </>
+              )}
+
+              {/* Show AI suggestion button after user has added some subs */}
+              {addedSubs.length > 0 && !aiFetched && !aiLoading && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full mt-2 text-xs"
+                  onClick={fetchAiSuggestions}
+                >
+                  <Sparkles className="mr-1.5 h-3 w-3" />
+                  Suggest more subreddits with AI
+                </Button>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-6 flex items-center justify-between">
+        <Button variant="ghost" onClick={onBack}>
+          <ArrowLeft className="mr-2 h-4 w-4" /> Back
+        </Button>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-muted-foreground">{addedSubs.length} selected</span>
+          <Button onClick={onNext} disabled={addedSubs.length === 0}>
+            Continue <ArrowRight className="ml-2 h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/onboarding/steps/ToneStep.tsx
+++ b/app/src/components/onboarding/steps/ToneStep.tsx
@@ -1,0 +1,378 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { ArrowLeft, X, Heart, Pen } from 'lucide-react';
+import { motion, AnimatePresence, useMotionValue, useTransform, type PanInfo } from 'motion/react';
+import { Button } from '@/components/ui/button';
+
+// 12 Reddit post styles from research, each with a short example post
+const POST_STYLES = [
+  {
+    id: 'struggle-discovery',
+    name: 'The Struggle & Discovery',
+    description: 'Personal story with a problem-solution arc',
+    exampleTitle: 'I was mass-sending cold emails for 6 months and getting zero replies. Here\'s what finally worked.',
+    exampleBody: 'I run a small consultancy and honestly, my outreach was embarrassing. I was blasting 200 cold emails a week with generic templates and getting maybe 1-2 replies a month. Last month I started personalizing the first line of every email automatically. My reply rate went from under 1% to 14% in three weeks. Happy to share my exact workflow if anyone\'s interested.',
+    exampleSubreddit: 'r/Entrepreneur',
+  },
+  {
+    id: 'curious-crowd',
+    name: 'The Curious Crowd',
+    description: 'Question that invites community discussion',
+    exampleTitle: 'Does anyone else feel like project management tools have gotten way too bloated?',
+    exampleBody: 'Genuine question — I manage a team of 8 and we\'ve cycled through Asana, Monday, and ClickUp over the past year. Every single one feels like it was designed for a 500-person enterprise, not a small team. Are we the only ones drowning in feature bloat, or is this just the state of PM tools now?',
+    exampleSubreddit: 'r/startups',
+  },
+  {
+    id: 'builders-showcase',
+    name: 'The Builder\'s Showcase',
+    description: '"I built this" maker post with feedback ask',
+    exampleTitle: 'Spent the last 4 months building a tool that turns meeting recordings into action items automatically. Would love honest feedback.',
+    exampleBody: 'I\'m a PM who was sick of leaving meetings with vague notes and no follow-through. It records your calls, transcribes them, and extracts actual action items with owners and deadlines. It\'s been running on my team of 12 for a month and has genuinely changed how we operate. I\'d love brutal feedback — here\'s a 2-minute demo.',
+    exampleSubreddit: 'r/SideProject',
+  },
+  {
+    id: 'psa-drop',
+    name: 'The PSA Drop',
+    description: 'Urgent insider tip or public service announcement',
+    exampleTitle: 'PSA: If you\'re still paying for Zapier\'s premium tier, you\'re probably overspending by 60%',
+    exampleBody: 'I just did an audit of our team\'s automation stack and realized we were paying $120/month when 90% of our workflows could run on a free tier alternative. Not affiliated at all — just frustrated with the pricing hike and started looking around. Check your usage before your next billing cycle.',
+    exampleSubreddit: 'r/SaaS',
+  },
+  {
+    id: 'showdown',
+    name: 'The Showdown',
+    description: 'Side-by-side comparison with a clear verdict',
+    exampleTitle: 'I tested Notion, Coda, and DocuFlow for 30 days each. Here\'s my brutally honest ranking.',
+    exampleBody: 'My 4-person startup was drowning in docs. Notion is powerful but overkill. Coda was flexible but the learning curve lost us a week. DocuFlow was the simplest — we migrated in 2 hours and the AI search actually works. Winner for small teams: DocuFlow. Winner for power users: Notion.',
+    exampleSubreddit: 'r/software',
+  },
+  {
+    id: 'open-floor',
+    name: 'The Open Floor',
+    description: 'Open-ended discussion starter, product in comments',
+    exampleTitle: 'What\'s your team using for async communication that actually works? Slack isn\'t cutting it anymore.',
+    exampleBody: 'We\'re 15 people, fully remote, and Slack has become a nightmare. Important messages get buried, threads go nowhere. What\'s actually working for your team? Especially from other remote teams in the 10-30 person range. Not looking for "just use email" — we tried that.',
+    exampleSubreddit: 'r/remotework',
+  },
+  {
+    id: 'playbook',
+    name: 'The Playbook',
+    description: 'Step-by-step tutorial with product woven in',
+    exampleTitle: 'How I automated 80% of my social media posting in under an hour (step-by-step)',
+    exampleBody: 'I run social for three clients and was spending 10+ hours a week scheduling. Here\'s my workflow: (1) Batch-create ideas with AI. (2) Auto-generate platform-specific variations. (3) Schedule everything in one sitting. (4) 15 min/day on engagement only. Total weekly time: 10 hours → 2.',
+    exampleSubreddit: 'r/marketing',
+  },
+  {
+    id: 'contrarian',
+    name: 'The Contrarian',
+    description: 'Hot take that challenges conventional wisdom',
+    exampleTitle: 'Unpopular opinion: Most A/B testing is a complete waste of time for startups under $1M ARR',
+    exampleBody: 'I know this sub loves A/B testing everything, but hear me out. I spent 200 hours on tests and never had enough traffic for statistical significance. What actually moved the needle? Talking to 10 customers and building what they asked for. I\'m not saying it\'s bad — I\'m saying it\'s premature optimization. Fight me.',
+    exampleSubreddit: 'r/Entrepreneur',
+  },
+  {
+    id: 'experiment-log',
+    name: 'The Experiment Log',
+    description: 'Data-driven "I tracked X for 30 days" format',
+    exampleTitle: 'I replaced our $200/month email stack with a $29 tool and tracked everything for 60 days. Here are the real numbers.',
+    exampleBody: 'Open rates went from 22.1% to 24.8%. Click rates stayed roughly the same (3.1% vs 3.3%). Revenue per email actually went up 11% but I think that\'s noise. Only downside: clunkier template builder. Net savings of $171/mo for basically the same performance. Full spreadsheet in comments.',
+    exampleSubreddit: 'r/SaaS',
+  },
+  {
+    id: 'casual-drop',
+    name: 'The Casual Drop',
+    description: 'Natural, offhand product mention within a broader topic',
+    exampleTitle: 'Remote team managers: how are you handling the "always online" burnout problem?',
+    exampleBody: 'The biggest issue isn\'t productivity — it\'s that everyone feels like they need to be online all the time. We\'ve tried no-meeting Fridays and async standups through BriefKit, which helped a bit, but the real problem is cultural. Has anyone found tactics that actually shift the always-on mentality?',
+    exampleSubreddit: 'r/management',
+  },
+  {
+    id: 'confessional-ama',
+    name: 'The Confessional AMA',
+    description: 'Transparent founder Q&A sharing real numbers',
+    exampleTitle: 'I bootstrapped a SaaS to $18K MRR in 14 months while working full-time. AMA about the messy reality.',
+    exampleBody: 'I launched 14 months ago, still have my day job, and just crossed $18K MRR with zero paid marketing. I\'ve made every mistake in the book — pricing too low, building features nobody wanted, almost burning out twice. I\'m going to be brutally honest. Revenue, costs, mistakes, everything. Ask me anything.',
+    exampleSubreddit: 'r/startups',
+  },
+  {
+    id: 'empathy-hook',
+    name: 'The Empathy Hook',
+    description: 'Emotional validation before a gentle solution',
+    exampleTitle: 'If your side project is moving slowly, it\'s probably not because you\'re lazy. It\'s because your tools are fighting you.',
+    exampleBody: 'I see so many posts from people beating themselves up for not shipping faster. But half the battle is wrestling with deployment pipelines and CI/CD setups designed for 50-person teams. Sometimes the bottleneck isn\'t your motivation — it\'s your stack. Give yourself some credit.',
+    exampleSubreddit: 'r/webdev',
+  },
+];
+
+const SWIPE_THRESHOLD = 100;
+
+interface ToneStepProps {
+  likedStyles: Set<string>;
+  onLikedStylesChange: (styles: Set<string>) => void;
+  completed: boolean;
+  onComplete: () => void;
+  onReset: () => void;
+  onBack: () => void;
+  onNext: () => void;
+}
+
+function PostCard({
+  style,
+  onPass,
+  onLike,
+  active,
+}: {
+  style: (typeof POST_STYLES)[number];
+  onPass: () => void;
+  onLike: () => void;
+  active: boolean;
+}) {
+  const x = useMotionValue(0);
+  const rotate = useTransform(x, [-200, 200], [-12, 12]);
+  const passOpacity = useTransform(x, [-200, -50], [1, 0]);
+  const likeOpacity = useTransform(x, [50, 200], [0, 1]);
+
+  const handleDragEnd = useCallback(
+    (_: unknown, info: PanInfo) => {
+      if (info.offset.x < -SWIPE_THRESHOLD) {
+        onPass();
+      } else if (info.offset.x > SWIPE_THRESHOLD) {
+        onLike();
+      }
+    },
+    [onPass, onLike]
+  );
+
+  if (!active) return null;
+
+  return (
+    <motion.div
+      className="absolute inset-0 cursor-grab active:cursor-grabbing"
+      style={{ x, rotate }}
+      drag="x"
+      dragConstraints={{ left: 0, right: 0 }}
+      dragElastic={0.8}
+      onDragEnd={handleDragEnd}
+      initial={{ scale: 0.95, opacity: 0 }}
+      animate={{ scale: 1, opacity: 1 }}
+      exit={{ opacity: 0, transition: { duration: 0.15 } }}
+      transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+    >
+      {/* Swipe indicators */}
+      <motion.div
+        className="absolute -left-3 top-1/2 -translate-y-1/2 z-10 flex h-12 w-12 items-center justify-center rounded-full bg-red-500/90 text-white shadow-lg"
+        style={{ opacity: passOpacity }}
+      >
+        <X className="h-6 w-6" />
+      </motion.div>
+      <motion.div
+        className="absolute -right-3 top-1/2 -translate-y-1/2 z-10 flex h-12 w-12 items-center justify-center rounded-full bg-green-500/90 text-white shadow-lg"
+        style={{ opacity: likeOpacity }}
+      >
+        <Heart className="h-6 w-6" />
+      </motion.div>
+
+      {/* Card */}
+      <div className="h-full rounded-2xl border bg-card shadow-xl overflow-hidden flex flex-col">
+        {/* Style header */}
+        <div className="px-5 pt-5 pb-3 border-b">
+          <div className="flex items-center gap-2">
+            <Pen className="h-4 w-4 text-orange-500" />
+            <span className="text-sm font-semibold text-orange-500">{style.name}</span>
+          </div>
+          <p className="text-xs text-muted-foreground mt-0.5">{style.description}</p>
+        </div>
+
+        {/* Example post */}
+        <div className="flex-1 p-5 overflow-y-auto">
+          <div className="rounded-xl border bg-muted/30 p-4">
+            <div className="flex items-center gap-2 mb-3">
+              <div className="h-6 w-6 rounded-full bg-orange-500/20 flex items-center justify-center">
+                <span className="text-[10px] font-bold text-orange-500">OP</span>
+              </div>
+              <span className="text-xs text-muted-foreground">{style.exampleSubreddit}</span>
+            </div>
+            <h3 className="font-semibold text-sm leading-snug">{style.exampleTitle}</h3>
+            <p className="text-sm text-muted-foreground mt-2.5 leading-relaxed">{style.exampleBody}</p>
+          </div>
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+export function ToneStep({ likedStyles, onLikedStylesChange, completed, onComplete, onReset, onBack, onNext }: ToneStepProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const isSwiping = !completed && currentIndex < POST_STYLES.length;
+  const currentStyle = POST_STYLES[currentIndex];
+
+  function handlePass() {
+    const nextIndex = currentIndex + 1;
+    setCurrentIndex(nextIndex);
+    if (nextIndex >= POST_STYLES.length) onComplete();
+  }
+
+  function handleLike() {
+    const next = new Set(likedStyles);
+    next.add(currentStyle.id);
+    onLikedStylesChange(next);
+    const nextIndex = currentIndex + 1;
+    setCurrentIndex(nextIndex);
+    if (nextIndex >= POST_STYLES.length) onComplete();
+  }
+
+  function handleRedo() {
+    setCurrentIndex(0);
+    onReset();
+  }
+
+  // Get the names of liked styles for the summary
+  const likedStyleNames = POST_STYLES.filter((s) => likedStyles.has(s.id));
+
+  // Completed state — show summary with redo option
+  if (completed) {
+    return (
+      <div className="w-full max-w-lg mx-auto flex flex-col" style={{ minHeight: '520px' }}>
+        <div className="text-center">
+          <h2 className="text-2xl font-bold tracking-tight">Your Writing DNA</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Your preferred Reddit post styles
+          </p>
+        </div>
+
+        <div className="flex-1 mt-6 mb-4 flex flex-col items-center justify-center text-center gap-5">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-orange-500/10">
+            <Heart className="h-7 w-7 text-orange-500" />
+          </div>
+          <div>
+            <p className="text-lg font-semibold">
+              {likedStyles.size === 0 ? 'No styles selected' : `${likedStyles.size} style${likedStyles.size === 1 ? '' : 's'} selected`}
+            </p>
+            <p className="text-sm text-muted-foreground mt-1 max-w-xs mx-auto">
+              {likedStyles.size === 0
+                ? 'You passed on all styles. Your posts will use default formatting.'
+                : 'These styles will shape how your AI-generated posts sound.'}
+            </p>
+          </div>
+
+          {likedStyleNames.length > 0 && (
+            <div className="flex flex-wrap justify-center gap-2 max-w-sm">
+              {likedStyleNames.map((style) => (
+                <span
+                  key={style.id}
+                  className="inline-flex items-center gap-1.5 rounded-full border bg-orange-500/5 border-orange-500/20 px-3 py-1.5 text-xs font-medium text-orange-600"
+                >
+                  <Pen className="h-3 w-3" />
+                  {style.name}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <button
+            onClick={handleRedo}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2"
+          >
+            Redo choices
+          </button>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <Button variant="ghost" onClick={onBack}>
+            <ArrowLeft className="mr-2 h-4 w-4" /> Back
+          </Button>
+          <Button onClick={onNext}>
+            Continue
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Swiping state — show cards
+  return (
+    <div className="w-full max-w-lg mx-auto flex flex-col" style={{ minHeight: '520px' }}>
+      {/* Header */}
+      <div className="text-center">
+        <h2 className="text-2xl font-bold tracking-tight">Your Writing DNA</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Like the Reddit post styles you want to write in
+        </p>
+      </div>
+
+      {/* Card area */}
+      <div className="relative flex-1 mt-6 mb-4" style={{ minHeight: '320px' }}>
+        <AnimatePresence mode="wait">
+          {isSwiping && currentStyle && (
+            <PostCard
+              key={currentStyle.id}
+              style={currentStyle}
+              onPass={handlePass}
+              onLike={handleLike}
+              active
+            />
+          )}
+        </AnimatePresence>
+      </div>
+
+      {/* Pass/Like buttons */}
+      {isSwiping && (
+        <div className="flex items-center justify-center gap-8 mb-4">
+          <button
+            onClick={handlePass}
+            className="flex flex-col items-center gap-1.5 group"
+          >
+            <div className="flex h-12 w-12 items-center justify-center rounded-full border-2 border-muted-foreground/20 text-muted-foreground transition-colors group-hover:border-red-500/50 group-hover:text-red-500">
+              <X className="h-5 w-5" />
+            </div>
+            <span className="text-xs text-muted-foreground group-hover:text-red-500 transition-colors">Pass</span>
+          </button>
+          <button
+            onClick={handleLike}
+            className="flex flex-col items-center gap-1.5 group"
+          >
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-orange-500 text-white transition-transform group-hover:scale-105">
+              <Heart className="h-5 w-5" />
+            </div>
+            <span className="text-xs text-orange-500 font-medium">Like</span>
+          </button>
+        </div>
+      )}
+
+      {/* Progress */}
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-xs text-muted-foreground">
+          {currentIndex + 1} of {POST_STYLES.length}
+        </span>
+        {likedStyles.size > 0 && (
+          <span className="text-xs text-muted-foreground">
+            {likedStyles.size} liked
+          </span>
+        )}
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden mb-6">
+        <motion.div
+          className="h-full bg-orange-500 rounded-full"
+          initial={{ width: 0 }}
+          animate={{ width: `${(currentIndex / POST_STYLES.length) * 100}%` }}
+          transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+        />
+      </div>
+
+      {/* Navigation */}
+      <div className="flex items-center justify-between">
+        <Button variant="ghost" onClick={onBack}>
+          <ArrowLeft className="mr-2 h-4 w-4" /> Back
+        </Button>
+        {likedStyles.size > 0 && (
+          <Button onClick={() => { onComplete(); onNext(); }}>
+            Continue
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/onboarding/steps/WelcomeStep.tsx
+++ b/app/src/components/onboarding/steps/WelcomeStep.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { ArrowRight, Sparkles, Target, Zap } from 'lucide-react';
+import { motion } from 'motion/react';
+import { Button } from '@/components/ui/button';
+import { staggerContainerVariants, staggerItemVariants } from '@/lib/motion';
+
+interface WelcomeStepProps {
+  userName: string;
+  onNext: () => void;
+}
+
+export function WelcomeStep({ userName, onNext }: WelcomeStepProps) {
+  const firstName = userName?.split(' ')[0] || 'there';
+
+  return (
+    <div className="flex flex-col items-center justify-center text-center">
+      <motion.div
+        initial={{ scale: 0.8, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ duration: 0.4, ease: [0.25, 0.1, 0.25, 1] }}
+        className="mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-orange-500 text-white"
+      >
+        <Sparkles className="h-8 w-8" />
+      </motion.div>
+
+      <h1 className="text-3xl font-bold tracking-tight">
+        Welcome, {firstName}!
+      </h1>
+      <p className="mt-2 max-w-md text-muted-foreground">
+        Let&apos;s set up your first Reddit marketing campaign. This takes about 2 minutes
+        and everything you share helps the AI find better communities and write more authentic content for you.
+      </p>
+
+      <motion.div
+        variants={staggerContainerVariants}
+        initial="hidden"
+        animate="visible"
+        className="mt-8 grid w-full max-w-md gap-3"
+      >
+        {[
+          {
+            icon: Target,
+            text: 'Describe your product',
+            sub: 'The more specific you are, the better the AI can match you to subreddits where your audience actually hangs out.',
+          },
+          {
+            icon: Sparkles,
+            text: 'AI finds your best subreddits',
+            sub: 'Your product details directly shape which communities get recommended \u2014 vague descriptions lead to generic results.',
+          },
+          {
+            icon: Zap,
+            text: 'Start creating content instantly',
+            sub: 'With the right context, generated posts sound authentic to each community instead of like a copy-paste ad.',
+          },
+        ].map(({ icon: Icon, text, sub }) => (
+          <motion.div
+            key={text}
+            variants={staggerItemVariants}
+            className="flex items-start gap-3 rounded-xl border bg-card p-3.5 text-left"
+          >
+            <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-orange-500/10">
+              <Icon className="h-4 w-4 text-orange-500" />
+            </div>
+            <div>
+              <span className="text-sm font-medium">{text}</span>
+              <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">{sub}</p>
+            </div>
+          </motion.div>
+        ))}
+      </motion.div>
+
+      <Button onClick={onNext} size="lg" className="mt-8">
+        Get Started <ArrowRight className="ml-2 h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/app/src/lib/ai/prompts.ts
+++ b/app/src/lib/ai/prompts.ts
@@ -16,8 +16,60 @@ What makes a good Reddit marketing post:
 - Admits flaws or limitations (builds trust)
 - Fits naturally into the subreddit's content mix`;
 
+// Maps writing style IDs to names and instructions for the AI
+const WRITING_STYLE_DESCRIPTIONS: Record<string, { name: string; instruction: string }> = {
+  'struggle-discovery': {
+    name: 'The Struggle & Discovery',
+    instruction: 'Write as a personal narrative: open with a specific pain point, walk through failed attempts, then reveal the product as the resolution. Use vulnerable, conversational language.',
+  },
+  'curious-crowd': {
+    name: 'The Curious Crowd',
+    instruction: 'Frame as a genuine question that invites community discussion. Position yourself as seeking advice while strategically surfacing the problem the product solves.',
+  },
+  'builders-showcase': {
+    name: "The Builder's Showcase",
+    instruction: 'Present as something you built. Mention specific effort invested, your motivation, and ask for honest feedback. Be proud but humble.',
+  },
+  'psa-drop': {
+    name: 'The PSA Drop',
+    instruction: 'Frame as an urgent insider tip or public service announcement. Lead with a problem or risk, then position the product as one recommendation among several.',
+  },
+  'showdown': {
+    name: 'The Showdown',
+    instruction: 'Structure as a side-by-side comparison where you tested multiple options. Be analytical, acknowledge competitor strengths, and declare a winner with nuance.',
+  },
+  'open-floor': {
+    name: 'The Open Floor',
+    instruction: 'Post a broad, open-ended question designed to spark discussion. Do NOT mention the product in the post body — save it for a natural comment reply.',
+  },
+  'playbook': {
+    name: 'The Playbook',
+    instruction: 'Write a step-by-step tutorial or guide. The product should appear naturally as a tool used in one step, not the focus of the entire guide.',
+  },
+  'contrarian': {
+    name: 'The Contrarian',
+    instruction: 'Open with a bold, slightly controversial opinion that challenges conventional wisdom. Back it with personal experience and position the product as evidence of the alternative approach.',
+  },
+  'experiment-log': {
+    name: 'The Experiment Log',
+    instruction: 'Document a structured experiment with specific metrics, timeframes, and measurable outcomes. Include exact numbers, surprises, and honest takeaways.',
+  },
+  'casual-drop': {
+    name: 'The Casual Drop',
+    instruction: 'Write a genuine post about a broader topic and mention the product in exactly one sentence as a natural, offhand detail. No pitch, no emphasis, no link.',
+  },
+  'confessional-ama': {
+    name: 'The Confessional AMA',
+    instruction: 'Write as a transparent founder or expert opening up for questions. Share real numbers, mistakes, and behind-the-scenes details. End with "AMA" or invite questions.',
+  },
+  'empathy-hook': {
+    name: 'The Empathy Hook',
+    instruction: 'Open by validating a common frustration the audience feels. Diagnose the real problem, reframe it, then gently introduce the product as one way to address it.',
+  },
+};
+
 export function buildGeneratePrompt(
-  product: { name: string; description: string; url?: string; audience?: string; tone: string },
+  product: { name: string; description: string; url?: string; audience?: string; tone: string; writingStyles?: string[] },
   examplePosts: { title: string; body: string | null; score: number; subreddit: string; numComments: number }[],
   count: number = 2
 ): string {
@@ -30,25 +82,42 @@ Body: ${p.body || '[No body text - link post]'}`
     )
     .join('\n\n');
 
+  // Build writing style instructions if styles were selected
+  const styles = product.writingStyles || [];
+  let styleSection = '';
+  if (styles.length > 0) {
+    const styleDescriptions = styles
+      .map((id) => WRITING_STYLE_DESCRIPTIONS[id])
+      .filter(Boolean)
+      .map((s) => `- **${s.name}:** ${s.instruction}`)
+      .join('\n');
+
+    styleSection = `\n## Preferred Writing Styles
+The user has chosen these Reddit post formats. Each generated post MUST use one of these styles. Vary the style across posts — use a different style for each post when possible.
+
+${styleDescriptions}
+`;
+  }
+
   return `## Product Context
 - **Product:** ${product.name}
 - **Description:** ${product.description}
 ${product.url ? `- **URL:** ${product.url}` : ''}
 ${product.audience ? `- **Target Audience:** ${product.audience}` : ''}
 - **Desired Tone:** ${product.tone}
-
+${styleSection}
 ## Successful Example Posts
 These posts performed well in their subreddits. Study their structure, tone, and engagement patterns:
 
 ${examplesText}
 
 ## Task
-Generate ${count} Reddit posts that promote "${product.name}" while matching the style and approach of the examples above.
+Generate ${count} Reddit posts that promote "${product.name}" while matching the style and approach of the examples above.${styles.length > 0 ? ' Each post MUST follow one of the preferred writing styles listed above. Include the style name in the strategy note.' : ''}
 
 For each post, provide:
 1. **Title** — Attention-grabbing, fits the subreddit style
 2. **Body** — Full post body in Reddit markdown
-3. **Strategy Note** — Brief explanation of why this approach works (1-2 sentences)
+3. **Strategy Note** — Brief explanation of why this approach works (1-2 sentences)${styles.length > 0 ? ' Include which writing style was used.' : ''}
 
 Format your response as JSON:
 {
@@ -103,37 +172,61 @@ Use this context to give more relevant and specific advice.`;
 
 // ---- Subreddit Discovery ----
 
-export const SUGGEST_SUBREDDITS_SYSTEM_PROMPT = `You are an expert Reddit strategist with deep knowledge of Reddit's subreddit ecosystem. You help product creators find the best subreddits to market their products authentically.
+export const SUGGEST_SUBREDDITS_SYSTEM_PROMPT = `You are an expert Reddit strategist. You help product creators find the best subreddits to market their products authentically.
 
-Your recommendations should:
-- Include a mix of large (>100K), medium (10K-100K), and niche (<10K) subreddits
-- Prioritize subreddits where self-promotion posts can succeed (not just pure discussion subs)
-- Consider the product's audience, tone, and category
-- Warn about subreddits with strict anti-promotion rules
-- Include subreddits people wouldn't think of (adjacent communities, hobby-specific, regional)
+CRITICAL RULES:
+- The TARGET AUDIENCE field is your #1 signal. These are the exact communities the user wants to reach. Find subreddits where those people actually congregate.
+- ONLY recommend subreddits that are directly relevant to the product's SPECIFIC niche. Do NOT suggest adjacent or tangential communities for other markets, games, or categories unless the product explicitly covers them.
+- If the product is about one specific thing (e.g. One Piece), do NOT suggest subreddits for other things in the same broader category (e.g. Pokemon, Magic: The Gathering).
+- NEVER suggest generic "showcase your project" subreddits (e.g. InternetIsBeautiful, SideProject, etc.) — only suggest communities where the target audience already exists.
+- Niche subreddits with small but highly targeted audiences are MORE valuable than large generic ones. Prioritize specificity over size.
+- NEVER suggest subreddits with fewer than 1,000 members. They are too small to be useful for promotion.
+- For match quality: "best" = the target audience IS this community, "good" = strong overlap with the target audience, "relevant" = related community worth trying.`;
 
-Always return real subreddits that actually exist on Reddit.`;
+export function buildSuggestSubredditsPrompt(
+  product: {
+    name: string;
+    description: string;
+    url?: string;
+    audience?: string;
+    tone: string;
+  },
+  discoveredSubreddits?: { name: string; subscribers: number; description: string }[],
+  existingSubreddits?: string[]
+): string {
+  const hasExisting = existingSubreddits && existingSubreddits.length > 0;
 
-export function buildSuggestSubredditsPrompt(product: {
-  name: string;
-  description: string;
-  url?: string;
-  audience?: string;
-  tone: string;
-}): string {
+  const existingSection = hasExisting
+    ? `\n## Subreddits Already Chosen by the User\nThe user has already added these subreddits to their campaign:\n${existingSubreddits.map((s) => `- r/${s}`).join('\n')}\n\nSuggest subreddits that are RELATED to or overlap with these communities. Think about: sister subreddits, adjacent interest communities, and subreddits where the same audience also participates. Do NOT suggest any of these subreddits — they are already added.\n`
+    : '';
+
+  const discoveredSection = discoveredSubreddits?.length
+    ? `\n## Real Subreddits Found on Reddit\nThese were found by searching Reddit directly. Include any that are relevant and add your own suggestions:\n${discoveredSubreddits.map((s) => `- r/${s.name} (${s.subscribers.toLocaleString()} members): ${s.description}`).join('\n')}\n`
+    : '';
+
+  const taskDescription = hasExisting
+    ? `Suggest 8-10 additional subreddits that complement the user's existing picks. Focus on communities that share the same audience as the subreddits they already chose — sister communities, related interest groups, and niche offshoots.`
+    : `Suggest 10-12 subreddits where this product's TARGET AUDIENCE actually spends time. Every suggestion must be a community where the people described above are active members — not just a subreddit where you could theoretically post about the product.`;
+
   return `## Product
 - **Name:** ${product.name}
 - **Description:** ${product.description}
 ${product.url ? `- **URL:** ${product.url}` : ''}
-${product.audience ? `- **Target Audience:** ${product.audience}` : ''}
 - **Tone:** ${product.tone}
 
+${product.audience ? `## Target Audience${!hasExisting ? ' (HIGHEST PRIORITY)' : ''}\nThese are the exact people we want to reach. Every subreddit you suggest should contain these people:\n**${product.audience}**\n\nFind subreddits where these specific groups gather. Niche communities that perfectly match these audiences are far more valuable than large generic ones.\n` : ''}
+${existingSection}
+${discoveredSection}
 ## Task
-Suggest 10-12 subreddits where this product could be authentically promoted. For each subreddit, provide:
+${taskDescription}
+
+IMPORTANT: Include a mix of subreddit sizes. At least 3-4 should be small niche communities (1K-10K members) that are highly specific to the target audience. These tight-knit communities are often the most valuable for authentic promotion. Do not only suggest large popular subreddits. Never suggest subreddits with fewer than 1,000 members.
+
+${discoveredSubreddits?.length ? 'Prioritize the real subreddits found above if they match the target audience, then add your own. ' : ''}For each subreddit, provide:
 1. The subreddit name (without r/ prefix)
 2. Why it's a good fit (1 sentence)
 3. A recommended approach for that specific community (1 sentence)
-4. Risk level: "low" (self-promo friendly), "medium" (allowed with value-add), or "high" (strict rules, tread carefully)
+4. Match quality: "best" (core niche community), "good" (strong audience overlap), or "relevant" (tangentially related but worth targeting). Order results by match quality, best first.
 
 Format as JSON:
 {
@@ -142,7 +235,7 @@ Format as JSON:
       "name": "subredditname",
       "reason": "Why this subreddit fits...",
       "approach": "How to post here...",
-      "risk": "low"
+      "match": "best"
     }
   ]
 }`;
@@ -152,7 +245,7 @@ export interface SuggestedSubreddit {
   name: string;
   reason: string;
   approach: string;
-  risk: 'low' | 'medium' | 'high';
+  match: 'best' | 'good' | 'relevant';
 }
 
 // ---- Subreddit Analysis ----

--- a/app/src/lib/supabase/middleware.ts
+++ b/app/src/lib/supabase/middleware.ts
@@ -29,25 +29,57 @@ export async function updateSession(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
+  const pathname = request.nextUrl.pathname;
+
   const isAuthPage =
-    request.nextUrl.pathname.startsWith('/login') ||
-    request.nextUrl.pathname.startsWith('/signup');
+    pathname.startsWith('/login') ||
+    pathname.startsWith('/signup');
+
+  const isOnboardingPage = pathname.startsWith('/onboarding');
 
   const isProtectedRoute =
-    request.nextUrl.pathname.startsWith('/projects') ||
-    request.nextUrl.pathname.startsWith('/chat') ||
-    request.nextUrl.pathname.startsWith('/inspiration');
+    pathname.startsWith('/projects') ||
+    pathname.startsWith('/chat') ||
+    pathname.startsWith('/inspiration') ||
+    pathname.startsWith('/bookmarks');
 
-  if (!user && isProtectedRoute) {
+  // Unauthenticated users can't access protected routes or onboarding
+  if (!user && (isProtectedRoute || isOnboardingPage)) {
     const url = request.nextUrl.clone();
     url.pathname = '/login';
     return NextResponse.redirect(url);
   }
 
+  // Authenticated users on auth pages → redirect to projects
   if (user && isAuthPage) {
     const url = request.nextUrl.clone();
     url.pathname = '/projects';
     return NextResponse.redirect(url);
+  }
+
+  // Onboarding gate: check if authenticated user has completed onboarding
+  if (user && (isProtectedRoute || isOnboardingPage)) {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('onboarding_completed')
+      .eq('id', user.id)
+      .single();
+
+    const onboardingCompleted = profile?.onboarding_completed ?? false;
+
+    // User hasn't completed onboarding → redirect to onboarding
+    if (!onboardingCompleted && isProtectedRoute) {
+      const url = request.nextUrl.clone();
+      url.pathname = '/onboarding';
+      return NextResponse.redirect(url);
+    }
+
+    // User already completed onboarding → redirect away from onboarding page
+    if (onboardingCompleted && isOnboardingPage) {
+      const url = request.nextUrl.clone();
+      url.pathname = '/projects';
+      return NextResponse.redirect(url);
+    }
   }
 
   return supabaseResponse;

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -7,6 +7,7 @@ export interface Profile {
   email: string;
   full_name: string | null;
   avatar_url: string | null;
+  onboarding_completed: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -20,6 +21,7 @@ export interface Project {
   product_url: string | null;
   target_audience: string | null;
   tone: string;
+  writing_styles: string[];
   created_at: string;
   updated_at: string;
 }
@@ -106,6 +108,7 @@ export interface ProductNodeData {
   url: string;
   audience: string;
   tone: string;
+  writingStyles?: string[];
   [key: string]: unknown;
 }
 
@@ -193,6 +196,7 @@ export interface GenerateRequest {
     url?: string;
     audience?: string;
     tone: string;
+    writingStyles?: string[];
   };
   examplePosts: {
     title: string;

--- a/app/supabase/migrations/003_onboarding.sql
+++ b/app/supabase/migrations/003_onboarding.sql
@@ -1,0 +1,6 @@
+-- Add onboarding tracking to profiles
+ALTER TABLE public.profiles ADD COLUMN onboarding_completed boolean NOT NULL DEFAULT false;
+
+-- Backfill existing users who already have projects
+UPDATE public.profiles SET onboarding_completed = true
+WHERE id IN (SELECT DISTINCT user_id FROM public.projects);

--- a/app/supabase/migrations/004_writing_styles.sql
+++ b/app/supabase/migrations/004_writing_styles.sql
@@ -1,0 +1,2 @@
+-- Add writing_styles column to projects
+ALTER TABLE public.projects ADD COLUMN writing_styles text[] NOT NULL DEFAULT '{}';

--- a/research/reddit-post-styles.md
+++ b/research/reddit-post-styles.md
@@ -1,0 +1,521 @@
+# Reddit Post Styles: A Comprehensive Guide to Writing DNA
+
+> Research document for SuperReddit's "Writing DNA" feature. Identifies 12 distinct Reddit post styles commonly used for organic product marketing and engagement. Each style is defined by its structure, tone, language patterns, and psychological triggers.
+
+---
+
+## Table of Contents
+
+1. [The Struggle & Discovery](#1-the-struggle--discovery)
+2. [The Curious Crowd](#2-the-curious-crowd)
+3. [The Builder's Showcase](#3-the-builders-showcase)
+4. [The PSA Drop](#4-the-psa-drop)
+5. [The Showdown](#5-the-showdown)
+6. [The Open Floor](#6-the-open-floor)
+7. [The Playbook](#7-the-playbook)
+8. [The Contrarian](#8-the-contrarian)
+9. [The Experiment Log](#9-the-experiment-log)
+10. [The Casual Drop](#10-the-casual-drop)
+11. [The Confessional AMA](#11-the-confessional-ama)
+12. [The Empathy Hook](#12-the-empathy-hook)
+13. [Summary Table](#summary-table)
+14. [Sources & Further Reading](#sources--further-reading)
+
+---
+
+## 1. The Struggle & Discovery
+
+**Also known as:** The Personal Story, The Origin Arc, The Hero's Journey
+
+### Description
+
+A first-person narrative that follows a classic problem-solution arc: the author was struggling with a specific pain point, tried various approaches, and eventually found (or built) something that worked. The tone is vulnerable, conversational, and relatable. Posts typically open with a pain point the reader can identify with, walk through the messy middle, and arrive at a resolution that naturally involves a product.
+
+**Structural pattern:**
+- Opening: Personal pain point or frustration ("I was spending 4 hours a day on X...")
+- Middle: Failed attempts or context ("I tried A, B, and C but nothing worked...")
+- Resolution: Discovery or creation of the solution ("Then I found / built Y...")
+- Outcome: Concrete results or relief ("Now I'm saving 3 hours a day...")
+
+**Language markers:** "I was struggling with...", "After months of...", "I finally found...", "Game changer for me...", "Honestly, I was about to give up..."
+
+### Why It Works
+
+This style leverages the psychology of narrative transportation -- when readers follow a personal story, they lower their critical defenses and empathize with the author. The vulnerability of admitting struggle creates trust, and the resolution feels earned rather than pitched. Research on viral Reddit posts shows that first-person narratives appear in 41% of top-performing posts, and vulnerability-driven content generates significantly higher comment volumes because readers want to share their own experiences. The story arc also creates a natural curiosity gap: once someone reads about the struggle, they want to know how it ends.
+
+### Example Post
+
+**Title:** I was mass-sending cold emails for 6 months and getting zero replies. Here's what finally worked.
+
+**Body:**
+I run a small B2B consultancy and honestly, my outreach was embarrassing. I was blasting 200 cold emails a week with generic templates and getting maybe 1-2 replies a month. I tried three different email tools, hired a VA, even took a $500 course on cold emailing. Nothing moved the needle. Last month I started using PipelineBot to analyze my prospects before reaching out and personalize the first line of every email automatically. My reply rate went from under 1% to 14% in three weeks. I know that sounds like an ad but I genuinely have no affiliation -- just a frustrated founder who finally found something that works. Happy to share my exact workflow if anyone's interested.
+
+### Best For
+
+- B2B SaaS tools that solve a clearly defined pain point
+- Productivity and workflow tools
+- Products targeting founders, freelancers, and small business owners
+- Any product where the "before and after" contrast is dramatic
+
+---
+
+## 2. The Curious Crowd
+
+**Also known as:** The Question Bait, The Poll, The "Am I Crazy?"
+
+### Description
+
+A post framed as a genuine question that invites the community to weigh in. The author positions themselves as seeking validation, advice, or shared experiences -- but the question is strategically crafted to surface a problem that the promoted product solves. The tone is curious, slightly uncertain, and community-oriented.
+
+**Structural pattern:**
+- Opening question: A relatable, slightly leading question ("Am I the only one who...?")
+- Context: Brief personal experience that frames the question (1-2 sentences)
+- Invitation: Explicit ask for community input ("What's everyone else doing?")
+- Optional: The author's current solution mentioned casually
+
+**Language markers:** "Am I the only one who...", "Does anyone else...", "Is it just me or...", "What do you guys use for...", "Has anyone figured out how to..."
+
+### Why It Works
+
+Question-format posts tap into Reddit's core identity as a discussion platform. They feel native to the medium because Reddit was literally built for asking and answering questions. The "Am I the only one?" framing triggers what psychologists call the false consensus effect -- readers who share the experience feel compelled to validate the poster, while those who disagree feel compelled to correct them. Either way, it drives comments. High comment counts push posts higher in Reddit's algorithm, creating a virtuous cycle. The format also disarms suspicion because it frames the author as a learner, not a promoter.
+
+### Example Post
+
+**Title:** Does anyone else feel like project management tools have gotten way too bloated?
+
+**Body:**
+Genuine question -- I manage a team of 8 and we've cycled through Asana, Monday, and ClickUp over the past year. Every single one feels like it was designed for a 500-person enterprise, not a small team that just needs to track tasks without a PhD in project management. We recently stumbled onto TaskFlow and it's the first tool that didn't make my eyes glaze over, but I'm curious what everyone else is using. Are we the only team drowning in feature bloat, or is this just the state of PM tools now?
+
+### Best For
+
+- Products in crowded markets where differentiation matters
+- Tools competing against well-known incumbents
+- Consumer products where community opinions carry weight
+- Any product launch where you want to understand (or shape) the conversation
+
+---
+
+## 3. The Builder's Showcase
+
+**Also known as:** The Show & Tell, The "I Built This", The Maker Post
+
+### Description
+
+The author presents something they created -- an app, tool, side project, or resource -- and invites feedback. The tone is proud but humble, emphasizing the effort and journey rather than features. Specificity is critical: mentioning exact hours spent, tech stack used, or problems encountered adds credibility. The post feels like a peer sharing their work, not a company launching a product.
+
+**Structural pattern:**
+- Hook: Time/effort invested + what was built ("Spent 6 months building a...")
+- Motivation: Why it was built (personal itch, frustration, curiosity)
+- Description: What it does (brief, benefit-focused, not feature-list)
+- Ask: Request for feedback, criticism, or suggestions
+- Optional: Link or screenshots
+
+**Language markers:** "I built...", "I spent X months/hours building...", "Here's what I made...", "After [time] of late nights...", "Would love your honest feedback...", "Roast my..."
+
+### Why It Works
+
+Reddit has a deep-rooted maker culture, especially in subreddits like r/SideProject, r/startups, r/webdev, and r/entrepreneur. Builder posts trigger what researchers call the "effort heuristic" -- people assign more value to things that clearly required significant effort. Including specific time investment ("292 hours and 30 minutes") dramatically increases perceived authenticity. The feedback request also lowers defenses because it frames the interaction as collaborative rather than promotional. Data from viral Reddit posts shows that builder posts with specific time hooks generate 3-5x more engagement than generic product announcements.
+
+### Example Post
+
+**Title:** Spent the last 4 months building a tool that turns meeting recordings into action items automatically. Would love honest feedback.
+
+**Body:**
+I'm a product manager who was sick of leaving meetings with vague notes and no follow-through. So I built MeetingMind -- it records your calls, transcribes them, and uses AI to extract the actual action items with owners and deadlines. It's been running on my team of 12 for the last month and has genuinely changed how we operate. I know the AI meeting space is crowded, so I'd love brutal feedback on what would actually make you try something like this. Here's a 2-minute demo if you're curious: [link]
+
+### Best For
+
+- Developer tools and technical products
+- Side projects and indie SaaS
+- Products with a strong founder story
+- Early-stage products seeking beta users and product-market fit
+
+---
+
+## 4. The PSA Drop
+
+**Also known as:** The Public Service Announcement, The Pro Tip, The "You Should Know"
+
+### Description
+
+The author frames their post as an important announcement or insider tip that the community needs to know about. The tone is authoritative, urgent, and helpful -- like a friend pulling you aside to share something important. The product mention feels incidental to the larger message, positioned as something the author discovered while trying to solve the broader problem.
+
+**Structural pattern:**
+- Attention grab: "PSA:", "YSK:", "Pro tip:", or "Heads up:"
+- The problem or risk: Something the audience should be aware of
+- The implication: Why this matters to them specifically
+- The solution/recommendation: The product positioned as one option among several
+- Optional: Supporting evidence or personal experience
+
+**Language markers:** "PSA:", "Heads up:", "You should know...", "Pro tip:", "TIL that...", "Just found out that...", "Wanted to warn everyone..."
+
+### Why It Works
+
+The PSA format borrows authority from the public service announcement genre -- it signals that the information is important and time-sensitive. On Reddit, posts prefixed with "PSA" consistently outperform similar posts without the prefix because the format creates urgency and positions the author as a community protector rather than a self-promoter. The psychological mechanism is reciprocity: the author is doing the community a favor, which makes readers more receptive to any product mention embedded in the message. The format also works because Reddit users value insider knowledge and "hidden gems" -- a PSA feels like exclusive information.
+
+### Example Post
+
+**Title:** PSA: If you're still paying for Zapier's premium tier, you're probably overspending by 60%
+
+**Body:**
+I just did an audit of our team's automation stack and realized we were paying $120/month for Zapier when 90% of our workflows could run on FlowStack's free tier. Not affiliated with them at all -- I was just frustrated with Zapier's pricing hike and started looking for alternatives. FlowStack handles multi-step automations, has a built-in database, and the free tier gives you 5,000 tasks/month. Thought I'd share since I've seen a lot of people here complaining about Zapier's new pricing. Check your usage before your next billing cycle.
+
+### Best For
+
+- Products that are significantly cheaper or free alternatives to incumbents
+- Security tools, privacy tools, or anything with urgency
+- Products in spaces where the audience is already frustrated with existing options
+- Seasonal or time-sensitive campaigns (pricing changes, new regulations, etc.)
+
+---
+
+## 5. The Showdown
+
+**Also known as:** The Comparison, The Versus Post, The "I Tried Both"
+
+### Description
+
+The author positions themselves as an impartial tester who tried multiple competing products and is sharing their honest findings. The post is structured as a direct comparison with clear categories, specific metrics, and a declared winner. The tone is analytical, fair-minded, and data-informed. Even when the post favors one product, it acknowledges the competitor's strengths to maintain credibility.
+
+**Structural pattern:**
+- Context: Why the comparison was needed ("My team needed a new X, so I tested the top options")
+- Methodology: How each was evaluated (time spent, criteria, use case)
+- Comparison: Side-by-side breakdown (features, pricing, UX, performance)
+- Verdict: Clear winner with nuance ("X wins for most people, but Y is better if...")
+- Optional: Table or formatted comparison
+
+**Language markers:** "I tried X vs Y...", "After using both for a month...", "Here's my honest comparison...", "The winner surprised me...", "I tested the top 5..."
+
+### Why It Works
+
+Comparison posts appeal to Reddit users because they mirror the research behavior people are already doing. A large percentage of Reddit traffic comes from people searching "[Product A] vs [Product B]" on Google, and these posts rank extremely well in search results, creating evergreen traffic. The format also works because it positions the author as a neutral evaluator, which triggers trust. By acknowledging both sides, the author avoids the "shill" accusation that kills most promotional Reddit posts. The SEO compounding effect is significant: a well-written comparison post on Reddit can drive qualified traffic for months or even years.
+
+### Example Post
+
+**Title:** I tested Notion, Coda, and DocuFlow for 30 days each to manage my startup's docs. Here's my brutally honest ranking.
+
+**Body:**
+My 4-person startup was drowning in docs spread across Google Drive, Notion, and random Slack messages. I committed to testing each tool exclusively for a month. Notion is powerful but felt like overkill -- we spent more time organizing than writing. Coda was flexible but the learning curve lost us a week. DocuFlow was the simplest by far: we had our entire knowledge base migrated in 2 hours, and the AI search actually finds things. Winner for small teams: DocuFlow. Winner for power users who love customization: Notion. Coda is great if you need database-level logic. Happy to answer questions about any of them.
+
+### Best For
+
+- Products that win on specific dimensions (price, simplicity, speed, niche feature)
+- Challenger brands competing against well-known market leaders
+- Products with strong differentiation that becomes clear in side-by-side comparison
+- SEO-driven content strategies targeting "vs" search queries
+
+---
+
+## 6. The Open Floor
+
+**Also known as:** The Discussion Starter, The Community Poll, The Roundtable
+
+### Description
+
+The author poses a broad, open-ended question designed to spark a multi-threaded discussion. The post intentionally does NOT mention a product upfront -- instead, it creates a conversation where the product can be mentioned naturally in the comments (either by the author or by genuine users). The tone is genuinely curious and community-focused.
+
+**Structural pattern:**
+- Question: Broad but specific enough to drive focused answers ("What's your go-to tool for X?")
+- Context: Brief framing of why the question matters (1-2 sentences)
+- Optional qualifiers: "Looking for recommendations for [specific use case]"
+- Comment strategy: Author participates actively, mentioning their product only when directly relevant
+
+**Language markers:** "What's everyone using for...", "How are you handling...", "What's your go-to...", "Curious what this sub thinks about...", "Looking for recommendations..."
+
+### Why It Works
+
+This style works because it mirrors how real Reddit discussions naturally start. It leverages the platform's core value proposition -- crowd-sourced recommendations from real users. Discussion posts generate the highest comment-to-upvote ratios on Reddit because they give every reader a reason to contribute their own experience. The format also creates space for organic product mentions in comments, which feel more trustworthy than post-level promotions. Reddit's algorithm heavily rewards comment volume, so discussion posts tend to stay visible longer than static content posts.
+
+### Example Post
+
+**Title:** What's your team using for async communication that actually works? Slack isn't cutting it anymore.
+
+**Body:**
+We're a 15-person remote team and Slack has become a nightmare. Important messages get buried, threads go nowhere, and everyone's always "catching up" on channels. I've been looking at alternatives but the space is overwhelming. What's actually working for your team? Especially interested in hearing from other remote teams in the 10-30 person range. Not looking for "just use email" answers -- we tried that and it was worse.
+
+### Best For
+
+- Products in recommendation-heavy categories (tools, software, services)
+- Community-driven brands that have genuine users willing to recommend them
+- Market research disguised as promotion (learn what users want while seeding awareness)
+- Products that perform well in word-of-mouth scenarios
+
+---
+
+## 7. The Playbook
+
+**Also known as:** The Tutorial, The Step-by-Step Guide, The How-To
+
+### Description
+
+The author provides a detailed, actionable guide that solves a specific problem. The product is woven into the tutorial as a tool used in one or more steps, but the guide provides genuine value even without the product. The tone is educational, structured, and generous with knowledge. Posts are typically longer and heavily formatted with headers, numbered lists, and bold text.
+
+**Structural pattern:**
+- Title: Clear outcome promised ("How to [achieve X] in [timeframe]")
+- Context: Why this matters and who it's for (1-2 sentences)
+- Steps: Numbered, actionable steps with enough detail to follow
+- Product integration: The product appears naturally as a tool used in 1-2 steps
+- Results: What the reader should expect after following the guide
+- Optional: "TL;DR" summary at the top or bottom
+
+**Language markers:** "Step 1:", "Here's exactly how I...", "A complete guide to...", "The exact process I use to...", "Follow these steps..."
+
+### Why It Works
+
+Tutorial posts are the highest-saved content type on Reddit because they provide lasting reference value. Users bookmark them, share them, and return to them -- creating sustained visibility. The format works for marketing because the product mention feels like a tool recommendation within genuinely helpful content, rather than the point of the post. Reddit rewards expertise, and a well-written tutorial establishes the author (and by extension, their product) as an authority. Tutorial posts also perform exceptionally well in search engines, creating long-tail organic traffic that compounds over time.
+
+### Example Post
+
+**Title:** How I automated 80% of my social media posting in under an hour (step-by-step)
+
+**Body:**
+I run social accounts for three small clients and was spending 10+ hours a week just scheduling posts. Here's my exact workflow now: (1) I batch-create a month of content ideas using ChatGPT with a custom prompt I'll share below. (2) I run them through ContentPilot to auto-generate platform-specific variations -- it handles character limits, hashtags, and image sizing automatically. (3) I schedule everything in one sitting using their calendar view. (4) I spend 15 min/day on engagement only. Total weekly time went from 10 hours to about 2. The biggest unlock was step 2 -- having a tool that adapts one piece of content to each platform saved me the most time. Happy to share my ChatGPT prompt in the comments if anyone wants it.
+
+### Best For
+
+- Products that fit into existing workflows (not complete replacements)
+- Tools with a clear "before and after" in efficiency
+- Products targeting skill-building audiences (marketers, developers, designers)
+- Content-heavy marketing strategies where SEO matters
+
+---
+
+## 8. The Contrarian
+
+**Also known as:** The Hot Take, The Unpopular Opinion, The Myth Buster
+
+### Description
+
+The author challenges a widely-held belief or popular tool/practice within the community. The tone is confident, slightly provocative, and backed by personal experience or data. The product is positioned as evidence of the alternative approach, not the point of the argument. The post is designed to split the audience and generate debate.
+
+**Structural pattern:**
+- Hot take: A bold, slightly controversial opening statement
+- The conventional wisdom: What most people believe (acknowledge it fairly)
+- The counter-argument: Why the author disagrees (backed by evidence)
+- The alternative: What they do instead (where the product can be introduced)
+- Invitation to debate: "Change my mind" or "Am I wrong?"
+
+**Language markers:** "Unpopular opinion:", "Hot take:", "I'm going to get downvoted for this, but...", "Controversial opinion:", "Am I wrong, or is [common practice] actually terrible?", "Stop doing X. Here's why."
+
+### Why It Works
+
+Contrarian posts are engagement machines because they trigger what psychologists call "need for cognitive closure" -- people who agree feel validated and upvote, while people who disagree feel compelled to argue in the comments. Research from the Wharton School shows that content evoking high-excitement emotions like surprise or disagreement is 28% more likely to be shared. On Reddit specifically, controversial posts generate 3-5x more comments than neutral ones, and Reddit's algorithm weighs comment activity heavily. The format also positions the author as an independent thinker, which builds credibility in communities that value contrarian perspectives.
+
+### Example Post
+
+**Title:** Unpopular opinion: Most A/B testing is a complete waste of time for startups under $1M ARR
+
+**Body:**
+I know this sub loves A/B testing everything, but hear me out. I ran a startup for 3 years and spent probably 200 hours setting up, running, and analyzing A/B tests. You know what moved the needle? Talking to 10 customers and just building what they asked for. At our scale, we never had enough traffic for statistical significance anyway. We switched to using InsightLoop for rapid user interviews instead of Optimizely for testing, and our feature adoption rate tripled. I'm not saying A/B testing is bad -- I'm saying it's a premature optimization for most early-stage companies. Fight me.
+
+### Best For
+
+- Products that represent a new approach or methodology
+- Disruptive tools challenging established industry practices
+- Thought leadership campaigns by opinionated founders
+- Products targeting audiences that value independent thinking (developers, founders, creators)
+
+---
+
+## 9. The Experiment Log
+
+**Also known as:** The Data Post, The "30 Days Of" Challenge, The Results Report
+
+### Description
+
+The author documents a structured experiment with specific metrics, timeframes, and measurable outcomes. The tone is scientific, transparent, and data-first. The post reads like a mini case study: hypothesis, methodology, results, and conclusions. Numbers are specific (not rounded), and both successes and failures are documented. The product appears as a variable in the experiment.
+
+**Structural pattern:**
+- Setup: What was tested, why, and for how long ("I tracked X for 30 days")
+- Methodology: How the experiment was conducted (tools used, metrics tracked)
+- Results: Specific numbers, ideally with before/after comparison
+- Surprises: What was unexpected (this is the engagement hook)
+- Takeaways: What the author learned and would do differently
+- Optional: Charts, screenshots, or data tables
+
+**Language markers:** "I tracked...", "After 30 days of...", "Here are the results...", "The data surprised me...", "I tested X for [timeframe], here's what happened...", "N=1 experiment:"
+
+### Why It Works
+
+Data-driven posts work on Reddit because they appeal to the platform's rationalist culture -- Redditors respect evidence over opinion. The experiment format also creates a powerful curiosity gap: the title promises results, and readers click to see the numbers. Specific metrics (not vague claims) trigger credibility heuristics -- "14.3% increase" is more believable than "huge improvement." The format is also highly shareable because it provides social currency: sharing data makes the sharer look informed. Posts in this style perform particularly well on subreddits like r/Entrepreneur, r/SaaS, r/marketing, and r/dataisbeautiful, where data literacy is high.
+
+### Example Post
+
+**Title:** I replaced our $200/month email marketing stack with a $29 tool and tracked everything for 60 days. Here are the real numbers.
+
+**Body:**
+We were using Mailchimp ($150/mo) + Zapier ($50/mo) for our e-commerce email flows. I switched us to MailForge ($29/mo) as an experiment and tracked open rates, click rates, revenue per email, and deliverability across 47 campaigns. Results: open rates went from 22.1% to 24.8% (their send-time optimization is legit), click rates stayed roughly the same (3.1% vs 3.3%), and deliverability was identical. Revenue per email actually went up 11% but I think that's noise. The only downside: their template builder is clunkier than Mailchimp's. Net savings of $171/mo for basically the same performance. Full spreadsheet in comments.
+
+### Best For
+
+- Products that can demonstrate measurable ROI
+- Cost-saving or efficiency tools where numbers tell the story
+- Products targeting data-driven audiences (marketers, engineers, analysts)
+- Competitive positioning against expensive incumbents
+
+---
+
+## 10. The Casual Drop
+
+**Also known as:** The Offhand Mention, The Stealth Recommendation, The Side Note
+
+### Description
+
+This is the most subtle style. The post is genuinely about a broader topic -- a question, a story, a discussion -- and the product is mentioned casually as one small detail within a larger narrative. There is no pitch, no CTA, and no emphasis on the product. The mention feels like how you'd talk about a tool in conversation with a friend: matter-of-fact and unremarkable.
+
+**Structural pattern:**
+- Main topic: A genuine post about something other than the product
+- Casual mention: The product appears in 1 sentence as a natural detail
+- No elaboration: No features listed, no selling, no links
+- Continued focus: The post continues on the main topic without dwelling on the product
+
+**Language markers:** "...I've been using X for that...", "...a tool called X handles this for us...", "...btw, X has been decent for this...", "...we ended up going with X which has been fine..."
+
+### Why It Works
+
+The casual drop works because it mirrors how real recommendations happen in life -- nobody pitches their friends on software; they just mention what they use. Reddit's community is hyper-sensitive to self-promotion, and the casual mention format passes the "authenticity sniff test" that kills most marketing posts. Psychologically, this leverages the "social proof" principle: a product mentioned casually in passing feels like an established, commonly-used tool rather than something being advertised. Research shows that when people discover a product through casual mention rather than direct marketing, they perceive it as a "hidden gem" and feel ownership over the discovery, increasing conversion likelihood.
+
+### Example Post
+
+**Title:** Remote team managers: how are you handling the "always online" burnout problem?
+
+**Body:**
+We went fully remote in 2022 and the biggest issue isn't productivity -- it's that everyone feels like they need to be online all the time. We've tried "no meeting Fridays" and async standups through BriefKit, which helped a bit, but the real problem is cultural. Even when we tell people to log off, they don't. I've started doing "loud logging off" where I visibly sign off in our team channel at 5pm sharp every day as the manager. Has anyone found other tactics that actually shift the always-on mentality?
+
+### Best For
+
+- Early-stage brand awareness campaigns (planting seeds, not harvesting)
+- Products that benefit from repeated exposure across multiple posts
+- Supplementary strategy used alongside more visible post styles
+- Brands building long-term presence on Reddit (the 90/10 rule)
+
+---
+
+## 11. The Confessional AMA
+
+**Also known as:** The Ask Me Anything, The Transparent Founder, The Open Book
+
+### Description
+
+The author opens themselves up to questions from the community, typically from a position of authority or unique experience. The format is inherently interactive -- the value is in the conversation itself, not the initial post. The tone is transparent, humble, and generous. For marketing purposes, the AMA is usually positioned around a journey or achievement, with the product as the vehicle.
+
+**Structural pattern:**
+- Credential/hook: What makes the author worth asking questions to
+- Brief backstory: The journey that led to this point (2-3 sentences)
+- Transparency promise: Willingness to share numbers, mistakes, and behind-the-scenes details
+- Open invitation: "AMA" or "Ask me anything" or "Happy to answer any questions"
+- Comment engagement: Author responds to every question in detail for 2-6 hours
+
+**Language markers:** "AMA", "Ask me anything", "I'll answer everything honestly", "Happy to share numbers", "No question is off limits", "I'm an open book"
+
+### Why It Works
+
+AMAs work because they flip the power dynamic -- the community controls the conversation, which feels empowering and authentic. Storytel's AMA campaign in storytelling subreddits generated a 3.4x lift in brand awareness and 266% higher engagement completion rates. The format creates reciprocity: the author gives transparent access, and the community rewards this with upvotes, engagement, and goodwill. AMAs also generate enormous comment volume, which keeps the post visible in Reddit's algorithm for hours. The evergreen nature of AMAs means they rank in brand searches indefinitely, creating long-tail discovery.
+
+### Example Post
+
+**Title:** I bootstrapped a SaaS to $18K MRR in 14 months while working full-time. AMA about the messy reality of building on the side.
+
+**Body:**
+Hey everyone. I'm the solo founder of DraftDeck, a proposal automation tool for freelancers. I launched 14 months ago, still have my day job, and just crossed $18K MRR with zero paid marketing. I've made every mistake in the book -- pricing too low, building features nobody wanted, almost burning out twice. I'm going to be brutally honest about all of it. Revenue, costs, time management, mistakes, things I'd do differently. Ask me anything for the next few hours.
+
+### Best For
+
+- Founder-led brands with compelling personal stories
+- Products with impressive growth metrics worth sharing
+- Companies wanting to build long-term community relationships
+- Launch campaigns timed around major milestones
+
+---
+
+## 12. The Empathy Hook
+
+**Also known as:** The Validation Post, The "Feeling This Too?", The Rallying Cry
+
+### Description
+
+The author opens with an emotionally resonant statement that validates a common frustration, insecurity, or aspiration shared by the community. The tone is warm, understanding, and slightly motivational. The post creates a sense of solidarity before gently introducing a solution. Unlike "The Struggle & Discovery" (which is a personal narrative), this style is outward-facing -- it's about the reader's pain, not the author's story.
+
+**Structural pattern:**
+- Empathy statement: Validate a common feeling ("Feeling overwhelmed by X? You're not alone.")
+- Diagnosis: Name the real problem (not the symptom)
+- Reframe: Offer a new way to think about the problem
+- Gentle solution: Introduce the product as one way to address the reframed problem
+- Encouragement: End with supportive, community-building language
+
+**Language markers:** "If you're feeling...", "You're not alone in...", "Here's what nobody tells you about...", "It's okay to...", "The real problem isn't X, it's Y..."
+
+### Why It Works
+
+Empathy-driven posts work because they make readers feel seen before being sold to. Research on Reddit engagement shows that posts beginning with emotional validation receive significantly higher engagement than those opening with facts or questions. The format leverages the psychological principle of "felt understanding" -- when someone articulates your unspoken frustration, you trust them. On Reddit specifically, empathetic posts like "Feeling overwhelmed? It's probably because you're trying to learn multiple technologies at the same time" have generated thousands of upvotes because they provide emotional relief alongside practical advice. The format also creates a safe space for comments, driving high engagement as readers share their own experiences.
+
+### Example Post
+
+**Title:** If your side project is moving slowly, it's probably not because you're lazy. It's because your tools are fighting you.
+
+**Body:**
+I see so many posts here from people beating themselves up for not shipping faster. But honestly? Half the battle is wrestling with deployment pipelines, environment configs, and CI/CD setups that were designed for 50-person teams. If you're a solo dev or a tiny team, you don't need enterprise infrastructure. We switched to ShipKit for deploys and went from "dreading every release" to pushing updates in under 2 minutes. Not saying tools fix everything, but sometimes the bottleneck isn't your motivation -- it's your stack. Give yourself some credit.
+
+### Best For
+
+- Products targeting audiences experiencing frustration or burnout
+- Developer tools, productivity apps, and wellness-related products
+- Community-building campaigns that prioritize brand affinity over conversion
+- Products that simplify or reduce complexity (the "relief" angle)
+
+---
+
+## Summary Table
+
+| # | Style Name | Tone | Structure | Product Visibility | Best Subreddits | Risk Level |
+|---|-----------|------|-----------|-------------------|-----------------|------------|
+| 1 | The Struggle & Discovery | Vulnerable, personal | Narrative arc (problem > journey > solution) | Medium -- product is the resolution | r/Entrepreneur, r/smallbusiness, r/productivity | Low |
+| 2 | The Curious Crowd | Curious, community-seeking | Question + context + invitation | Low -- mentioned casually if at all | r/AskReddit-style subs, niche communities | Very Low |
+| 3 | The Builder's Showcase | Proud but humble, maker | Effort hook + motivation + ask for feedback | High -- product is the subject | r/SideProject, r/startups, r/webdev | Medium |
+| 4 | The PSA Drop | Authoritative, urgent | Alert + problem + solution + evidence | Medium -- product is one recommendation | Any niche sub, r/LifeProTips | Low |
+| 5 | The Showdown | Analytical, balanced | Context + methodology + comparison + verdict | High -- product wins the comparison | r/SaaS, r/software, niche tool subs | Medium |
+| 6 | The Open Floor | Genuinely curious | Open question + context + comment engagement | Very Low -- product lives in comments | Any active discussion sub | Very Low |
+| 7 | The Playbook | Educational, generous | Steps + product as one tool in the workflow | Medium -- product is part of process | r/marketing, r/webdev, skill-based subs | Low |
+| 8 | The Contrarian | Provocative, confident | Bold claim + evidence + alternative approach | Medium -- product supports the argument | r/Entrepreneur, debate-friendly subs | High |
+| 9 | The Experiment Log | Scientific, transparent | Hypothesis + method + results + takeaways | Medium-High -- product is the variable | r/Entrepreneur, r/marketing, r/dataisbeautiful | Low |
+| 10 | The Casual Drop | Conversational, natural | Main topic + incidental product mention | Very Low -- 1 sentence, no emphasis | Any subreddit | Very Low |
+| 11 | The Confessional AMA | Transparent, generous | Credential + story + open Q&A | High -- product is the vehicle for the story | r/IAmA, r/Entrepreneur, niche subs | Medium |
+| 12 | The Empathy Hook | Warm, validating | Empathy + diagnosis + reframe + gentle solution | Low-Medium -- product is secondary to the message | r/learnprogramming, r/freelance, support subs | Low |
+
+### Quick Reference: Choosing a Style
+
+| Your Goal | Recommended Styles |
+|-----------|-------------------|
+| Brand awareness (top of funnel) | The Casual Drop, The Open Floor, The Curious Crowd |
+| Product launch | The Builder's Showcase, The Confessional AMA, The Struggle & Discovery |
+| Competitive positioning | The Showdown, The PSA Drop, The Contrarian |
+| SEO / evergreen traffic | The Showdown, The Playbook, The Experiment Log |
+| Community building | The Open Floor, The Empathy Hook, The Confessional AMA |
+| Direct conversion | The Experiment Log, The PSA Drop, The Struggle & Discovery |
+
+### Risk Levels Explained
+
+- **Very Low:** Post feels entirely organic. No product pitch. Extremely hard to detect as marketing.
+- **Low:** Product is mentioned but not the focus. Passes the authenticity sniff test for most Redditors.
+- **Medium:** Product is clearly visible. Works well in maker/startup communities but may trigger suspicion in general subs.
+- **High:** Post is overtly opinionated or product-focused. High engagement potential but also high risk of backlash if perceived as inauthentic.
+
+---
+
+## Sources & Further Reading
+
+- [How to Use Reddit for Marketing in 2025: Organic & Paid Strategies](https://almcorp.com/blog/reddit-marketing-strategies-2025/)
+- [5 Effective Reddit Marketing Strategies for Brands in 2026](https://www.mentionlytics.com/blog/reddit-marketing-the-ultimate-guide/)
+- [Reddit Marketing: The 2026 Playbook for Brands](https://outorigin.com/resources/reddit-marketing-playbook/)
+- [Reddit Post Templates That Actually Go Viral (With Real Examples)](https://growthexe.substack.com/p/55-reddit-post-templates-to-get-clients)
+- [9 Proven Reddit SaaS Plays to Avoid Backlash](https://www.subredditsignals.com/blog/stop-value-post-backlash-saas-reddit-marketing-that-actually-drives-leads-without-getting-banned)
+- [Reddit Marketing: 9 Safe Steps (2026 Guide)](https://www.subredditsignals.com/blog/what-is-reddit-marketing-the-2026-definition-real-examples-and-a-safe-starter-checklist-without-getting-banned)
+- [Creating Viral Reddit Posts](https://www.neapowers.com/marketing/creating-viral-reddit-posts/)
+- [The Magic Formula Behind Going Viral on Reddit for Product Launches](https://medium.com/design-bootcamp/the-magic-formula-behind-going-viral-on-reddit-for-your-product-launch-6f945666eff5)
+- [How SaaS Companies Can Use Reddit to Drive Results](https://foundationinc.co/lab/saas-success-on-reddit)
+- [Reddit Marketing for SaaS Companies](https://influencermarketinghub.com/reddit-marketing-for-saas-companies/)
+- [The Psychology of Reddit Upvotes: Why Social Proof Drives Visibility](https://techbullion.com/the-psychology-of-reddit-upvotes-why-social-proof-drives-visibility-in-2026/)
+- [Reddit AMA Ads: Case Studies That Generated $50K+ in Leads](https://www.subredditsignals.com/blog/reddit-ama-ads-lead-generation-case-studies-winning-strategies-2025)
+- [How to Run a Successful Reddit AMA Campaign for Your Brand](https://influencermarketinghub.com/reddit-ama-campaign/)
+- [Using Reddit for Organic Brand Promotion: A Step-by-Step Guide](https://www.francescatabor.com/articles/2025/8/21/using-reddit-for-organic-brand-promotion-a-step-by-step-guide)
+- [Step-By-Step Reddit Marketing Strategy for SaaS Companies](https://www.infrasity.com/blog/reddit-marketing-strategy)


### PR DESCRIPTION
## Summary
- **5-step onboarding flow** (Welcome → Product → Subreddits → Writing DNA → All Set) that collects product info, discovers subreddits via Reddit search + AI suggestions, and lets users pick writing styles through a Tinder-like swipe UI
- **Smart subreddit discovery**: searches Reddit directly, feeds real results to Claude for curation, verifies AI suggestions exist, auto-includes strong keyword matches, and supports context-aware "suggest more" based on user's existing picks
- **Writing styles wired end-to-end**: 12 post styles (Struggle & Discovery, Builder's Showcase, PSA Drop, etc.) saved to DB and injected into AI generation prompts so generated posts follow the user's preferred formats
- **Completion page** with personalized greeting, setup stats, and "Start Growing on Reddit" CTA — auto-creates project + canvas with product node, subreddit nodes, and edges on finish

## Test plan
- [ ] Sign up a new account → should redirect to `/onboarding` after email confirm
- [ ] Complete all 5 steps: fill product info, search/add subreddits, swipe through writing styles, confirm on completion page
- [ ] Verify subreddit search autocomplete works and AI suggestions load when requested
- [ ] Verify writing style swipe UI: drag left to pass, drag right to like, progress bar updates
- [ ] Navigate back and forth between steps — all state (product fields, subreddits, liked styles) should persist
- [ ] Click "Start Growing on Reddit" → project created with product + subreddit nodes on canvas
- [ ] Existing users with projects should be unaffected (`onboarding_completed` backfilled)
- [ ] Visiting `/onboarding` after completion → redirected to `/projects`

🤖 Generated with [Claude Code](https://claude.com/claude-code)