### PR TITLE
Add project dashboard with trending posts and analytics

### DIFF
--- a/app/src/app/api/reddit/trending/route.ts
+++ b/app/src/app/api/reddit/trending/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { searchSubredditPosts, fetchSubredditPosts } from '@/lib/reddit/fetcher';
+import type { RedditPost } from '@/types';
+
+export async function GET(request: NextRequest) {
+  const projectId = request.nextUrl.searchParams.get('projectId');
+  if (!projectId) {
+    return NextResponse.json({ error: 'projectId is required' }, { status: 400 });
+  }
+
+  const supabase = await createClient();
+
+  // Fetch project (for product_name) and its subreddits
+  const [projectRes, subredditsRes] = await Promise.all([
+    supabase.from('projects').select('product_name').eq('id', projectId).single(),
+    supabase.from('subreddits').select('name').eq('project_id', projectId).limit(6),
+  ]);
+
+  if (projectRes.error || !projectRes.data) {
+    return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+  }
+
+  const subreddits = subredditsRes.data ?? [];
+  if (subreddits.length === 0) {
+    return NextResponse.json({ posts: [], empty: true });
+  }
+
+  const productName = projectRes.data.product_name;
+  const postsBySub: Map<string, RedditPost[]> = new Map();
+
+  // For each subreddit: search by product name, fallback to top posts
+  await Promise.all(
+    subreddits.map(async (sub) => {
+      const posts: RedditPost[] = [];
+      const searchResult = await searchSubredditPosts(sub.name, productName, 10);
+      const searchPosts = searchResult.posts ?? [];
+      posts.push(...searchPosts);
+
+      if (searchPosts.length < 3) {
+        const topResult = await fetchSubredditPosts(sub.name, 'top', 'month', 10);
+        posts.push(...(topResult.posts ?? []));
+      }
+
+      // Dedupe within this subreddit and sort by score
+      const seen = new Set<string>();
+      const unique = posts.filter((p) => {
+        if (seen.has(p.id)) return false;
+        seen.add(p.id);
+        return true;
+      });
+      unique.sort((a, b) => b.score - a.score);
+      postsBySub.set(sub.name, unique);
+    })
+  );
+
+  // Guarantee minimum representation per subreddit, then fill by score
+  const TOTAL = 12;
+  const minPerSub = Math.min(3, Math.floor(TOTAL / postsBySub.size));
+  const result: RedditPost[] = [];
+  const usedIds = new Set<string>();
+
+  // Phase 1: take top N from each subreddit
+  for (const posts of postsBySub.values()) {
+    for (const post of posts.slice(0, minPerSub)) {
+      if (!usedIds.has(post.id)) {
+        result.push(post);
+        usedIds.add(post.id);
+      }
+    }
+  }
+
+  // Phase 2: fill remaining slots by score across all subreddits
+  const remaining = Array.from(postsBySub.values())
+    .flat()
+    .filter((p) => !usedIds.has(p.id))
+    .sort((a, b) => b.score - a.score);
+
+  for (const post of remaining) {
+    if (result.length >= TOTAL) break;
+    result.push(post);
+  }
+
+  // Final sort by score for display
+  result.sort((a, b) => b.score - a.score);
+
+  return NextResponse.json({ posts: result });
+}

--- a/app/src/app/projects/[id]/canvas/page.tsx
+++ b/app/src/app/projects/[id]/canvas/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useProject } from '@/contexts/project-context';
+import { Canvas } from '@/components/canvas/Canvas';
+import { FadeIn } from '@/components/motion';
+
+export default function ProjectCanvasPage() {
+  const project = useProject();
+
+  return (
+    <FadeIn className="flex h-full flex-col">
+      <div className="flex h-12 items-center gap-3 border-b bg-card px-4">
+        <div className="flex-1">
+          <h1 className="text-sm font-semibold">{project.name}</h1>
+          <p className="text-xs text-muted-foreground">{project.product_name}</p>
+        </div>
+        <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+          Auto-saving
+        </span>
+      </div>
+      <div className="flex-1">
+        <Canvas project={project} />
+      </div>
+    </FadeIn>
+  );
+}

--- a/app/src/app/projects/[id]/page.tsx
+++ b/app/src/app/projects/[id]/page.tsx
@@ -1,26 +1,184 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useProject } from '@/contexts/project-context';
-import { Canvas } from '@/components/canvas/Canvas';
+import { createClient } from '@/lib/supabase/client';
 import { FadeIn } from '@/components/motion';
+import { AnalyticsCards } from '@/components/dashboard/AnalyticsCards';
+import { ActivityHeatmap } from '@/components/dashboard/ActivityHeatmap';
+import { PlanProgress } from '@/components/dashboard/PlanProgress';
+import { TrendingPosts } from '@/components/dashboard/TrendingPosts';
+import { Skeleton } from '@/components/ui/skeleton';
 
-export default function ProjectCanvasPage() {
+interface SparklineData {
+  total: number;
+  daily: number[];
+}
+
+interface DashboardData {
+  postsDrafted: SparklineData;
+  postsPublished: SparklineData;
+  totalUpvotes: SparklineData;
+  totalComments: SparklineData;
+  hasSubreddits: boolean;
+  hasResearch: boolean;
+  hasDrafts: boolean;
+  hasEdited: boolean;
+  hasPublished: boolean;
+  activityDays: Record<string, number>;
+}
+
+const SPARKLINE_DAYS = 30;
+
+function buildDailyBuckets(dates: string[]): number[] {
+  const buckets: Record<string, number> = {};
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  // Initialize all days to 0
+  for (let i = SPARKLINE_DAYS - 1; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    buckets[toDateKey(d)] = 0;
+  }
+  // Fill in actual counts
+  for (const dateStr of dates) {
+    const key = toDateKey(dateStr);
+    if (key in buckets) {
+      buckets[key]++;
+    }
+  }
+  // Return as ordered array (oldest first)
+  return Object.values(buckets);
+}
+
+function toDateKey(input: string | Date): string {
+  const d = typeof input === 'string' ? new Date(input) : input;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export default function ProjectDashboardPage() {
   const project = useProject();
+  const [data, setData] = useState<DashboardData | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      const supabase = createClient();
+
+      const [subredditsRes, genPostsRes, discoveredRes, chatRes] = await Promise.all([
+        supabase
+          .from('subreddits')
+          .select('id', { count: 'exact', head: true })
+          .eq('project_id', project.id),
+        supabase
+          .from('generated_posts')
+          .select('status, created_at')
+          .eq('project_id', project.id),
+        supabase
+          .from('discovered_posts')
+          .select('fetched_at')
+          .eq('project_id', project.id),
+        supabase
+          .from('chat_messages')
+          .select('created_at')
+          .eq('project_id', project.id)
+          .eq('role', 'user'),
+      ]);
+
+      const subredditCount = subredditsRes.count ?? 0;
+      const genPosts = genPostsRes.data ?? [];
+      const discovered = discoveredRes.data ?? [];
+      const chatMessages = chatRes.data ?? [];
+
+      const published = genPosts.filter((p) => p.status === 'posted');
+      const hasEdited = genPosts.some((p) => p.status === 'edited' || p.status === 'posted');
+      const emptyDaily = new Array(SPARKLINE_DAYS).fill(0);
+
+      // Build sparkline data
+      const postsDrafted: SparklineData = {
+        total: genPosts.length,
+        daily: buildDailyBuckets(genPosts.map((p) => p.created_at)),
+      };
+      const postsPublished: SparklineData = {
+        total: published.length,
+        daily: buildDailyBuckets(published.map((p) => p.created_at)),
+      };
+      // Engagement metrics — populated once post tracking is added
+      const totalUpvotes: SparklineData = { total: 0, daily: emptyDaily };
+      const totalComments: SparklineData = { total: 0, daily: emptyDaily };
+
+      // Build activity map
+      const activityDays: Record<string, number> = {};
+      const addActivity = (dateStr: string) => {
+        const key = toDateKey(dateStr);
+        activityDays[key] = (activityDays[key] || 0) + 1;
+      };
+
+      genPosts.forEach((p) => addActivity(p.created_at));
+      discovered.forEach((p) => addActivity(p.fetched_at));
+      chatMessages.forEach((m) => addActivity(m.created_at));
+
+      setData({
+        postsDrafted,
+        postsPublished,
+        totalUpvotes,
+        totalComments,
+        hasSubreddits: subredditCount > 0,
+        hasResearch: discovered.length > 0,
+        hasDrafts: genPosts.length > 0,
+        hasEdited,
+        hasPublished: published.length > 0,
+        activityDays,
+      });
+    }
+
+    load();
+  }, [project.id]);
+
+  if (!data) {
+    return (
+      <div className="space-y-4 p-5">
+        <Skeleton className="h-8 w-48" />
+        <div className="grid grid-cols-3 gap-4">
+          <Skeleton className="col-span-2 h-56 rounded-xl" />
+          <Skeleton className="h-56 rounded-xl" />
+        </div>
+        <Skeleton className="h-40 rounded-xl" />
+      </div>
+    );
+  }
 
   return (
-    <FadeIn className="flex h-full flex-col">
-      <div className="flex h-12 items-center gap-3 border-b bg-card px-4">
-        <div className="flex-1">
-          <h1 className="text-sm font-semibold">{project.name}</h1>
-          <p className="text-xs text-muted-foreground">{project.product_name}</p>
+    <FadeIn className="space-y-4 p-5">
+      <div>
+        <h1 className="text-xl font-semibold">{project.name}</h1>
+        <p className="text-sm text-muted-foreground">{project.product_name}</p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <div className="col-span-2">
+          <AnalyticsCards
+            postsDrafted={data.postsDrafted}
+            postsPublished={data.postsPublished}
+            totalUpvotes={data.totalUpvotes}
+            totalComments={data.totalComments}
+          />
         </div>
-        <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-          Auto-saving
-        </span>
+        <PlanProgress
+          projectId={project.id}
+          hasSubreddits={data.hasSubreddits}
+          hasResearch={data.hasResearch}
+          hasDrafts={data.hasDrafts}
+          hasEdited={data.hasEdited}
+          hasPublished={data.hasPublished}
+        />
       </div>
-      <div className="flex-1">
-        <Canvas project={project} />
-      </div>
+
+      <ActivityHeatmap activityDays={data.activityDays} />
+
+      <TrendingPosts projectId={project.id} />
     </FadeIn>
   );
 }

--- a/app/src/components/dashboard/ActivityHeatmap.tsx
+++ b/app/src/components/dashboard/ActivityHeatmap.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Flame } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+interface ActivityHeatmapProps {
+  /** Map of ISO date string (YYYY-MM-DD) → activity count */
+  activityDays: Record<string, number>;
+}
+
+const WEEKS = 52;
+const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+function getColor(count: number): string {
+  if (count === 0) return 'bg-muted/50';
+  if (count <= 2) return 'bg-orange-500/30';
+  if (count <= 5) return 'bg-orange-500/50';
+  if (count <= 10) return 'bg-orange-500/75';
+  return 'bg-orange-500';
+}
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function toDateKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+export function ActivityHeatmap({ activityDays }: ActivityHeatmapProps) {
+  const { cells, monthLabels, streak } = useMemo(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    // Find the start: go back WEEKS * 7 days, then align to Sunday
+    const start = new Date(today);
+    start.setDate(start.getDate() - (WEEKS * 7 - 1) - today.getDay());
+
+    // Build cells
+    const totalDays = WEEKS * 7;
+    const cellList: { date: Date; dateKey: string; count: number; col: number; row: number }[] = [];
+    const monthSet = new Map<string, number>(); // month label → column index
+
+    for (let i = 0; i < totalDays; i++) {
+      const d = new Date(start);
+      d.setDate(start.getDate() + i);
+      const col = Math.floor(i / 7);
+      const row = i % 7;
+      const dateKey = toDateKey(d);
+      const count = activityDays[dateKey] || 0;
+
+      cellList.push({ date: d, dateKey, count, col, row });
+
+      // Track month labels (first occurrence of each month)
+      if (row === 0) {
+        const monthKey = d.toLocaleDateString('en-US', { month: 'short' });
+        if (!monthSet.has(monthKey)) {
+          monthSet.set(monthKey, col);
+        }
+      }
+    }
+
+    // Calculate streak: walk backward from today (skip today if 0)
+    let streakCount = 0;
+    const todayKey = toDateKey(today);
+    const startOffset = (activityDays[todayKey] || 0) === 0 ? 1 : 0;
+
+    for (let i = startOffset; i < totalDays; i++) {
+      const d = new Date(today);
+      d.setDate(today.getDate() - i);
+      const key = toDateKey(d);
+      if ((activityDays[key] || 0) > 0) {
+        streakCount++;
+      } else {
+        break;
+      }
+    }
+
+    return {
+      cells: cellList,
+      monthLabels: Array.from(monthSet.entries()),
+      streak: streakCount,
+    };
+  }, [activityDays]);
+
+  const streakMessage =
+    streak === 0
+      ? 'Start your streak today!'
+      : streak === 1
+        ? 'Keep it going tomorrow!'
+        : `Keep the momentum going!`;
+
+  return (
+    <Card className="gap-3 py-4">
+      <CardHeader className="pb-0">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-sm">Activity</CardTitle>
+          <div className="flex items-center gap-2 text-sm">
+            <Flame className="h-4 w-4 text-orange-500" />
+            <span className="font-semibold">{streak}-day streak</span>
+            <span className="text-muted-foreground">— {streakMessage}</span>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <TooltipProvider>
+          <div className="overflow-x-auto">
+            {/* Month labels */}
+            <div className="relative mb-1" style={{ paddingLeft: 32, height: 14 }}>
+              {monthLabels.map(([label, col]) => (
+                <span
+                  key={`${label}-${col}`}
+                  className="absolute text-[10px] text-muted-foreground"
+                  style={{ left: 32 + col * 16 }}
+                >
+                  {label}
+                </span>
+              ))}
+            </div>
+
+            <div className="flex gap-[3px]">
+              {/* Day labels */}
+              <div className="flex flex-col gap-[3px] pr-1" style={{ width: 28 }}>
+                {DAY_LABELS.map((label, i) => (
+                  <div
+                    key={label}
+                    className="flex h-[13px] items-center text-[10px] text-muted-foreground"
+                  >
+                    {i % 2 === 1 ? label : ''}
+                  </div>
+                ))}
+              </div>
+
+              {/* Grid */}
+              <div
+                className="grid flex-1 gap-[3px]"
+                style={{
+                  gridTemplateRows: 'repeat(7, 13px)',
+                  gridAutoFlow: 'column',
+                  gridAutoColumns: '1fr',
+                }}
+              >
+                {cells.map(({ dateKey, date, count }) => (
+                  <Tooltip key={dateKey}>
+                    <TooltipTrigger asChild>
+                      <div
+                        className={`h-[13px] rounded-[2px] ${getColor(count)}`}
+                      />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {count} {count === 1 ? 'activity' : 'activities'} on{' '}
+                      {formatDate(date)}
+                    </TooltipContent>
+                  </Tooltip>
+                ))}
+              </div>
+            </div>
+
+            {/* Legend */}
+            <div className="mt-2 flex items-center justify-end gap-1.5">
+              <span className="text-[10px] text-muted-foreground">Less</span>
+              <div className="h-[13px] w-[13px] rounded-[2px] bg-muted/50" />
+              <div className="h-[13px] w-[13px] rounded-[2px] bg-orange-500/30" />
+              <div className="h-[13px] w-[13px] rounded-[2px] bg-orange-500/50" />
+              <div className="h-[13px] w-[13px] rounded-[2px] bg-orange-500/75" />
+              <div className="h-[13px] w-[13px] rounded-[2px] bg-orange-500" />
+              <span className="text-[10px] text-muted-foreground">More</span>
+            </div>
+          </div>
+        </TooltipProvider>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/src/components/dashboard/AnalyticsCards.tsx
+++ b/app/src/components/dashboard/AnalyticsCards.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useMemo } from 'react';
+
+interface Metric {
+  label: string;
+  total: number;
+  /** Daily counts for the last 30 days, oldest first */
+  sparkline: number[];
+  color: string;
+}
+
+interface AnalyticsCardsProps {
+  postsDrafted: { total: number; daily: number[] };
+  postsPublished: { total: number; daily: number[] };
+  totalUpvotes: { total: number; daily: number[] };
+  totalComments: { total: number; daily: number[] };
+}
+
+function Sparkline({ data, color }: { data: number[]; color: string }) {
+  const { points, max } = useMemo(() => {
+    const m = Math.max(...data, 1);
+    const h = 32;
+    const w = 200;
+    const step = w / (data.length - 1 || 1);
+    const pts = data
+      .map((v, i) => `${i * step},${h - (v / m) * (h - 4) - 2}`)
+      .join(' ');
+    return { points: pts, max: m };
+  }, [data]);
+
+  return (
+    <svg
+      viewBox="0 0 200 32"
+      preserveAspectRatio="none"
+      className="h-8 w-full"
+    >
+      {max > 0 && (
+        <polyline
+          points={points}
+          fill="none"
+          stroke={color}
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      )}
+      {/* Flat line when no data */}
+      {max <= 0 && (
+        <line
+          x1="0" y1="30" x2="200" y2="30"
+          stroke={color}
+          strokeWidth="2.5"
+          strokeOpacity="0.3"
+        />
+      )}
+    </svg>
+  );
+}
+
+export function AnalyticsCards({
+  postsDrafted,
+  postsPublished,
+  totalUpvotes,
+  totalComments,
+}: AnalyticsCardsProps) {
+  const metrics: Metric[] = [
+    { label: 'POSTS DRAFTED', total: postsDrafted.total, sparkline: postsDrafted.daily, color: '#a855f7' },
+    { label: 'POSTS PUBLISHED', total: postsPublished.total, sparkline: postsPublished.daily, color: '#22c55e' },
+    { label: 'TOTAL UPVOTES', total: totalUpvotes.total, sparkline: totalUpvotes.daily, color: '#f97316' },
+    { label: 'TOTAL COMMENTS', total: totalComments.total, sparkline: totalComments.daily, color: '#3b82f6' },
+  ];
+
+  return (
+    <div className="grid h-full grid-cols-2 gap-3">
+      {metrics.map((m) => (
+        <div
+          key={m.label}
+          className="flex flex-col justify-between rounded-xl border bg-card px-4 pt-3 pb-0 overflow-hidden"
+        >
+          <div>
+            <p className="text-[11px] font-medium tracking-wider text-muted-foreground">
+              {m.label}
+            </p>
+            <p className="text-2xl font-bold">{m.total}</p>
+          </div>
+          <div className="-mx-4 mt-auto">
+            <Sparkline data={m.sparkline} color={m.color} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/src/components/dashboard/PlanProgress.tsx
+++ b/app/src/components/dashboard/PlanProgress.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import Link from 'next/link';
+import { Check } from 'lucide-react';
+import { motion } from 'motion/react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface PlanProgressProps {
+  projectId: string;
+  hasSubreddits: boolean;
+  hasResearch: boolean;
+  hasDrafts: boolean;
+  hasEdited: boolean;
+  hasPublished: boolean;
+}
+
+const STEPS = [
+  { label: 'Set up your product', ctaLabel: '', ctaPath: '' },
+  { label: 'Add target subreddits', ctaLabel: 'Go to Canvas', ctaPath: '/canvas' },
+  { label: 'Research inspiration posts', ctaLabel: 'Go to Inspiration', ctaPath: '/inspiration' },
+  { label: 'Generate draft posts', ctaLabel: 'Go to Canvas', ctaPath: '/canvas' },
+  { label: 'Refine your drafts', ctaLabel: 'Go to Canvas', ctaPath: '/canvas' },
+  { label: 'Publish to Reddit', ctaLabel: 'Go to Canvas', ctaPath: '/canvas' },
+];
+
+export function PlanProgress({
+  projectId,
+  hasSubreddits,
+  hasResearch,
+  hasDrafts,
+  hasEdited,
+  hasPublished,
+}: PlanProgressProps) {
+  const completions = [true, hasSubreddits, hasResearch, hasDrafts, hasEdited, hasPublished];
+
+  // Current step is the first incomplete step
+  let currentStep = completions.findIndex((c) => !c);
+  if (currentStep === -1) currentStep = STEPS.length; // all complete
+
+  const base = `/projects/${projectId}`;
+
+  return (
+    <Card className="gap-3 py-4">
+      <CardHeader className="pb-0">
+        <CardTitle className="text-sm">Your Reddit Marketing Plan</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <nav>
+          {STEPS.map((step, i) => {
+            const isCompleted = i < currentStep;
+            const isCurrent = i === currentStep;
+
+            return (
+              <div key={step.label} className="flex items-center gap-3 py-1.5">
+                <div className="relative flex h-6 w-6 shrink-0 items-center justify-center">
+                  {isCompleted ? (
+                    <motion.div
+                      initial={{ scale: 0.8 }}
+                      animate={{ scale: 1 }}
+                      className="flex h-6 w-6 items-center justify-center rounded-full bg-orange-500 text-white"
+                    >
+                      <Check className="h-3 w-3" />
+                    </motion.div>
+                  ) : (
+                    <div
+                      className={`h-6 w-6 rounded-full border-2 transition-colors ${
+                        isCurrent
+                          ? 'border-orange-500 bg-orange-500/10'
+                          : 'border-muted-foreground/20'
+                      }`}
+                    >
+                      {isCurrent && (
+                        <motion.div
+                          layoutId="plan-step-dot"
+                          className="absolute inset-[5px] rounded-full bg-orange-500"
+                        />
+                      )}
+                    </div>
+                  )}
+                </div>
+                <div className="flex flex-1 items-center justify-between gap-2">
+                  <span
+                    className={`text-sm transition-colors ${
+                      isCurrent
+                        ? 'font-medium text-foreground'
+                        : isCompleted
+                          ? 'text-muted-foreground'
+                          : 'text-muted-foreground/50'
+                    }`}
+                  >
+                    {step.label}
+                  </span>
+                  {isCurrent && step.ctaPath && (
+                    <Link
+                      href={`${base}${step.ctaPath}`}
+                      className="shrink-0 rounded-md bg-orange-500 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-orange-600"
+                    >
+                      {step.ctaLabel}
+                    </Link>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </nav>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/src/components/dashboard/StatsCards.tsx
+++ b/app/src/components/dashboard/StatsCards.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { FileText, Send, Radio, Search } from 'lucide-react';
+import { motion } from 'motion/react';
+import { staggerContainerVariants, staggerItemVariants } from '@/lib/motion';
+
+interface StatsCardsProps {
+  postsDrafted: number;
+  postsPublished: number;
+  subreddits: number;
+  postsResearched: number;
+}
+
+const stats = [
+  { key: 'postsDrafted', label: 'POSTS DRAFTED', icon: FileText, color: 'bg-purple-500/10 text-purple-500' },
+  { key: 'postsPublished', label: 'POSTS PUBLISHED', icon: Send, color: 'bg-green-500/10 text-green-500' },
+  { key: 'subreddits', label: 'SUBREDDITS', icon: Radio, color: 'bg-blue-500/10 text-blue-500' },
+  { key: 'postsResearched', label: 'POSTS RESEARCHED', icon: Search, color: 'bg-orange-500/10 text-orange-500' },
+] as const;
+
+export function StatsCards({ postsDrafted, postsPublished, subreddits, postsResearched }: StatsCardsProps) {
+  const values: Record<string, number> = { postsDrafted, postsPublished, subreddits, postsResearched };
+
+  return (
+    <motion.div
+      variants={staggerContainerVariants}
+      initial="hidden"
+      animate="visible"
+      className="grid grid-cols-2 gap-3 lg:grid-cols-4"
+    >
+      {stats.map((stat) => (
+        <motion.div
+          key={stat.key}
+          variants={staggerItemVariants}
+          className="flex items-center gap-3 rounded-xl border bg-card px-4 py-3"
+        >
+          <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full ${stat.color}`}>
+            <stat.icon className="h-5 w-5" />
+          </div>
+          <div>
+            <p className="text-2xl font-bold">{values[stat.key]}</p>
+            <p className="text-[11px] font-medium tracking-wider text-muted-foreground">{stat.label}</p>
+          </div>
+        </motion.div>
+      ))}
+    </motion.div>
+  );
+}

--- a/app/src/components/dashboard/TrendingPosts.tsx
+++ b/app/src/components/dashboard/TrendingPosts.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { TrendingUp, ArrowUpRight, MessageSquare, Clock, ExternalLink } from 'lucide-react';
+import Link from 'next/link';
+import type { RedditPost } from '@/types';
+
+interface TrendingPostsProps {
+  projectId: string;
+}
+
+function formatNumber(n: number) {
+  if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
+  return n.toString();
+}
+
+function timeAgo(timestamp: number) {
+  const seconds = Math.floor(Date.now() / 1000 - timestamp);
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`;
+  return new Date(timestamp * 1000).toLocaleDateString();
+}
+
+function TrendingPostCard({ post }: { post: RedditPost }) {
+  return (
+    <a
+      href={`https://reddit.com${post.permalink}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block break-inside-avoid mb-3"
+    >
+      <div className="group rounded-xl border border-border bg-card p-4 space-y-3 transition-colors hover:border-orange-500/40 hover:bg-accent/30">
+        {/* Subreddit badge */}
+        <span className="inline-flex items-center gap-1 rounded-full bg-muted/80 px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+          <svg className="h-2.5 w-2.5 shrink-0 fill-orange-500" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="10" cy="10" r="10" />
+          </svg>
+          r/{post.subreddit}
+        </span>
+
+        {/* Score + Title */}
+        <div className="flex gap-3">
+          <div className="flex flex-col items-center shrink-0 pt-0.5">
+            <ArrowUpRight className="h-3.5 w-3.5 text-orange-500" />
+            <span className="text-xs font-bold text-orange-500">{formatNumber(post.score)}</span>
+          </div>
+          <h3 className="text-sm font-medium leading-snug">{post.title}</h3>
+        </div>
+
+        {/* Preview image */}
+        {post.preview_url && (
+          <div className="overflow-hidden rounded-lg">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={post.preview_url}
+              alt=""
+              className="w-full object-cover rounded-lg transition-transform duration-300 group-hover:scale-[1.02]"
+              loading="lazy"
+            />
+          </div>
+        )}
+
+        {/* Body text */}
+        {post.selftext && (
+          <p className="text-xs text-muted-foreground leading-relaxed line-clamp-3">
+            {post.selftext}
+          </p>
+        )}
+
+        {/* Flair */}
+        {post.link_flair_text && (
+          <span className="inline-flex items-center rounded-full bg-muted px-2.5 py-0.5 text-[10px] font-medium">
+            {post.link_flair_text}
+          </span>
+        )}
+
+        {/* Metadata row */}
+        <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <MessageSquare className="h-3 w-3" />
+            {formatNumber(post.num_comments)}
+          </span>
+          <span className="flex items-center gap-1">
+            <Clock className="h-3 w-3" />
+            {timeAgo(post.created_utc)}
+          </span>
+          <span className="truncate">u/{post.author}</span>
+          <ExternalLink className="ml-auto h-3 w-3 shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
+        </div>
+      </div>
+    </a>
+  );
+}
+
+export function TrendingPosts({ projectId }: TrendingPostsProps) {
+  const [posts, setPosts] = useState<RedditPost[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [empty, setEmpty] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/reddit/trending?projectId=${projectId}`);
+        const data = await res.json();
+        if (data.empty) {
+          setEmpty(true);
+        } else {
+          setPosts(data.posts ?? []);
+        }
+      } catch {
+        // silently fail — section is non-critical
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [projectId]);
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <TrendingUp className="h-4 w-4" />
+            Trending in Your Subreddits
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="columns-3 gap-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton
+                key={i}
+                className="mb-3 break-inside-avoid rounded-xl"
+                style={{ height: `${120 + (i % 3) * 60}px` }}
+              />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (empty) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <TrendingUp className="h-4 w-4" />
+            Trending in Your Subreddits
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            No subreddits tracked yet.{' '}
+            <Link href={`/projects/${projectId}/canvas`} className="text-primary underline">
+              Open Canvas
+            </Link>{' '}
+            to add subreddits and see trending posts here.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (posts.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <TrendingUp className="h-4 w-4" />
+          Trending in Your Subreddits
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="columns-3 gap-3">
+          {posts.map((post) => (
+            <TrendingPostCard key={post.id} post={post} />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/src/components/inspiration/PostCard.tsx
+++ b/app/src/components/inspiration/PostCard.tsx
@@ -44,6 +44,18 @@ export function PostCard({ post, onUsePost, isBookmarked, onToggleBookmark }: Po
             <div className="flex-1 min-w-0 space-y-2">
               <h3 className="font-medium text-sm leading-snug">{post.title}</h3>
 
+              {post.preview_url && (
+                <div className="relative w-full overflow-hidden rounded-md">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={post.preview_url}
+                    alt=""
+                    className="w-full max-h-48 object-cover rounded-md"
+                    loading="lazy"
+                  />
+                </div>
+              )}
+
               {post.selftext && (
                 <p className="text-xs text-muted-foreground line-clamp-3">
                   {post.selftext}

--- a/app/src/components/layout/project-sidebar.tsx
+++ b/app/src/components/layout/project-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { ArrowLeft, LayoutDashboard, MessageSquare, Compass, Bookmark, LogOut } from 'lucide-react';
+import { ArrowLeft, LayoutDashboard, PenTool, MessageSquare, Compass, Bookmark, LogOut } from 'lucide-react';
 import { motion } from 'motion/react';
 import { createClient } from '@/lib/supabase/client';
 import { cn } from '@/lib/utils';
@@ -16,7 +16,8 @@ export function ProjectSidebar({ project }: { project: Project }) {
   const base = `/projects/${project.id}`;
 
   const navItems = [
-    { href: base, label: 'Canvas', icon: LayoutDashboard, exact: true },
+    { href: base, label: 'Dashboard', icon: LayoutDashboard, exact: true },
+    { href: `${base}/canvas`, label: 'Canvas', icon: PenTool },
     { href: `${base}/chat`, label: 'AI Chat', icon: MessageSquare },
     { href: `${base}/inspiration`, label: 'Inspiration', icon: Compass },
     { href: `${base}/bookmarks`, label: 'Bookmarks', icon: Bookmark },

--- a/app/src/lib/reddit/fetcher.ts
+++ b/app/src/lib/reddit/fetcher.ts
@@ -55,6 +55,20 @@ function setMemoryCache(key: string, data: RedditApiResponse) {
 }
 
 // ---- Parser ----
+function extractPreviewUrl(data: Record<string, unknown>): string | null {
+  try {
+    const preview = data.preview as { images?: { source?: { url?: string } }[] } | undefined;
+    const sourceUrl = preview?.images?.[0]?.source?.url;
+    if (sourceUrl) {
+      // Reddit HTML-encodes URLs in preview data
+      return sourceUrl.replace(/&amp;/g, '&');
+    }
+  } catch {
+    // ignore malformed preview data
+  }
+  return null;
+}
+
 function parseRedditPost(raw: Record<string, unknown>): RedditPost {
   const data = raw.data as Record<string, unknown>;
   return {
@@ -71,6 +85,8 @@ function parseRedditPost(raw: Record<string, unknown>): RedditPost {
     link_flair_text: (data.link_flair_text as string) || null,
     is_self: data.is_self as boolean,
     thumbnail: (data.thumbnail as string) || null,
+    preview_url: extractPreviewUrl(data),
+    post_hint: (data.post_hint as string) || null,
   };
 }
 

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -168,6 +168,8 @@ export interface RedditPost {
   link_flair_text: string | null;
   is_self: boolean;
   thumbnail: string | null;
+  preview_url: string | null;
+  post_hint: string | null;
 }
 
 export interface RedditSubredditInfo {


### PR DESCRIPTION
## Summary
- Restructure project page from canvas-only to a full dashboard with analytics cards, activity heatmap, and plan progress tracker
- Add trending Reddit posts section that fetches viral posts from tracked subreddits with balanced per-subreddit representation
- Parse Reddit preview images and display them in a bento-style masonry grid with subreddit badges
- Move canvas to its own `/canvas` sub-route and add it to the sidebar navigation

## Test plan
- [ ] Dashboard loads with analytics cards, heatmap, and plan progress
- [ ] Trending posts section shows posts from all tracked subreddits (not just one)
- [ ] Posts with images display preview thumbnails in the masonry layout
- [ ] Each post card shows the subreddit badge (r/name) at the top
- [ ] Empty state renders with link to Canvas when no subreddits are tracked
- [ ] Canvas page still works at `/projects/[id]/canvas`
- [ ] Build passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)