### PR TITLE
Add Outreach tab skeleton — signals, tracker, competitors

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -35,7 +35,9 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
+        "pg": "^8.18.0",
         "shadcn": "^3.8.4",
+        "supabase": "^2.76.8",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5"
@@ -127,6 +129,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -695,6 +698,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1607,6 +1611,19 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1903,6 +1920,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3618,6 +3636,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.95.3.tgz",
       "integrity": "sha512-Fukw1cUTQ6xdLiHDJhKKPu6svEPaCEDvThqCne3OaQyZvuq2qjhJAd91kJu3PXLG18aooCgYBaB6qQz35hhABg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.95.3",
         "@supabase/functions-js": "2.95.3",
@@ -4109,6 +4128,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4119,6 +4139,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4197,6 +4218,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -4776,6 +4798,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5182,6 +5205,23 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bin-links": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.0.tgz",
+      "integrity": "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "read-cmd-shim": "^6.0.0",
+        "write-file-atomic": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -5251,6 +5291,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5438,6 +5479,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -5586,6 +5637,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmd-shim": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
+      "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/code-block-writer": {
@@ -5832,6 +5893,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6487,6 +6549,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6672,6 +6735,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7807,6 +7871,7 @@
       "integrity": "sha512-eVkB/CYCCei7K2WElZW9yYQFWssG0DhaDhVvr7wy5jJ22K+ck8fWW0EsLpB0sITUTvPnc97+rrbQqIr5iqiy9Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10215,6 +10280,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/motion": {
       "version": "12.33.0",
       "resolved": "https://registry.npmjs.org/motion/-/motion-12.33.0.tgz",
@@ -10505,6 +10593,16 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
@@ -10969,6 +11067,104 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
+      "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.11.0",
+        "pg-pool": "^3.11.0",
+        "pg-protocol": "^1.11.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.11.0.tgz",
+      "integrity": "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
+      "integrity": "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
+      "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -11051,6 +11247,49 @@
         "node": ">=4"
       }
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/powershell-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
@@ -11088,6 +11327,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/prompts": {
@@ -11305,6 +11554,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11314,6 +11564,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11422,6 +11673,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/read-cmd-shim": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
+      "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/recast": {
@@ -12211,6 +12472,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -12525,6 +12796,26 @@
         }
       }
     },
+    "node_modules/supabase": {
+      "version": "2.76.8",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.76.8.tgz",
+      "integrity": "sha512-Mhu3KNioxSjymdaHu6hQ/qZKzu/v1AzIEnYOOZ9+ATtSfrQNjqiMg9sivKx1vToKqcDBm3BXjmg8OX65sZW2Pw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bin-links": "^6.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "node-fetch": "^3.3.2",
+        "tar": "7.5.7"
+      },
+      "bin": {
+        "supabase": "bin/supabase"
+      },
+      "engines": {
+        "npm": ">=8"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12595,6 +12886,33 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -12653,6 +12971,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12936,6 +13255,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13498,6 +13818,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/write-file-atomic": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.0.tgz",
+      "integrity": "sha512-YnlPC6JqnZl6aO4uRc+dx5PHguiR9S6WeoLtpxNT9wIG+BDya7ZNE1q7KOjVgaA73hKhKLpVPgJ5QA9THQ5BRg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
@@ -13534,6 +13868,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {
@@ -13672,6 +14016,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/app/package.json
+++ b/app/package.json
@@ -36,7 +36,9 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "pg": "^8.18.0",
     "shadcn": "^3.8.4",
+    "supabase": "^2.76.8",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"

--- a/app/src/app/api/ai/outreach-reply/route.ts
+++ b/app/src/app/api/ai/outreach-reply/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAnthropicClient, AI_MODEL, MAX_TOKENS } from '@/lib/ai/client';
+import { REPLY_DRAFT_SYSTEM_PROMPT, buildReplyDraftPrompt } from '@/lib/ai/prompts';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { signal_id, project_id, reply_mode } = body;
+
+    if (!signal_id || !project_id) {
+      return NextResponse.json(
+        { error: 'signal_id and project_id are required' },
+        { status: 400 }
+      );
+    }
+
+    const supabase = await createClient();
+
+    // Get signal
+    const { data: signal } = await supabase
+      .from('outreach_signals')
+      .select('*')
+      .eq('id', signal_id)
+      .single();
+
+    if (!signal) {
+      return NextResponse.json({ error: 'Signal not found' }, { status: 404 });
+    }
+
+    // Get project for product context
+    const { data: project } = await supabase
+      .from('projects')
+      .select('product_name, product_description, product_url')
+      .eq('id', project_id)
+      .single();
+
+    if (!project) {
+      return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+    }
+
+    // Get subreddit compliance notes if available
+    const { data: rules } = await supabase
+      .from('subreddit_rules')
+      .select('compliance_profile, safety_score')
+      .eq('subreddit', signal.subreddit)
+      .maybeSingle();
+
+    let complianceNotes: string | null = null;
+    if (rules?.compliance_profile) {
+      const profile = rules.compliance_profile as Record<string, unknown>;
+      const notes: string[] = [];
+      if (!profile.selfPromoAllowed) notes.push('Self-promotion is NOT allowed');
+      if (!profile.linkPostsAllowed) notes.push('Link posts are restricted');
+      if (profile.flairRequired) notes.push('Flair is required');
+      if (profile.restrictedKeywords) {
+        const kws = profile.restrictedKeywords as string[];
+        if (kws.length > 0) notes.push(`Restricted keywords: ${kws.join(', ')}`);
+      }
+      if (notes.length > 0) complianceNotes = notes.join('\n');
+    }
+
+    const client = getAnthropicClient();
+    const mode = reply_mode || 'helpful';
+    const prompt = buildReplyDraftPrompt(
+      {
+        title: signal.title,
+        body: signal.body,
+        subreddit: signal.subreddit,
+        author: signal.author,
+      },
+      {
+        name: project.product_name,
+        description: project.product_description,
+        url: project.product_url || undefined,
+      },
+      complianceNotes,
+      mode
+    );
+
+    const message = await client.messages.create({
+      model: AI_MODEL,
+      max_tokens: MAX_TOKENS,
+      system: REPLY_DRAFT_SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const textContent = message.content.find((c) => c.type === 'text');
+    if (!textContent || textContent.type !== 'text') {
+      return NextResponse.json({ error: 'No response from AI' }, { status: 500 });
+    }
+
+    let responseText = textContent.text.trim();
+    if (responseText.startsWith('```')) {
+      responseText = responseText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+    }
+
+    const parsed = JSON.parse(responseText) as { reply: string };
+
+    // Save reply draft
+    const { data: reply, error: replyError } = await supabase
+      .from('outreach_replies')
+      .insert({
+        project_id,
+        signal_id,
+        thread_permalink: signal.permalink,
+        draft_text: parsed.reply,
+        reply_mode: mode,
+        status: 'draft',
+      })
+      .select()
+      .single();
+
+    if (replyError) {
+      // Still return the draft even if save failed
+      return NextResponse.json({ reply: parsed.reply, saved: false });
+    }
+
+    return NextResponse.json({ reply: parsed.reply, reply_id: reply.id, saved: true });
+  } catch (error) {
+    console.error('Outreach reply error:', error);
+    return NextResponse.json({ error: 'Failed to generate reply' }, { status: 500 });
+  }
+}

--- a/app/src/app/api/outreach/config/route.ts
+++ b/app/src/app/api/outreach/config/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function GET(request: NextRequest) {
+  try {
+    const projectId = request.nextUrl.searchParams.get('project_id');
+    if (!projectId) {
+      return NextResponse.json({ error: 'project_id is required' }, { status: 400 });
+    }
+
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from('outreach_configs')
+      .select('*')
+      .eq('project_id', projectId)
+      .maybeSingle();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ config: data });
+  } catch (error) {
+    console.error('Outreach config GET error:', error);
+    return NextResponse.json({ error: 'Failed to fetch outreach config' }, { status: 500 });
+  }
+}

--- a/app/src/app/api/outreach/keywords/generate/route.ts
+++ b/app/src/app/api/outreach/keywords/generate/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAnthropicClient, AI_MODEL, MAX_TOKENS } from '@/lib/ai/client';
+import { KEYWORD_GEN_SYSTEM_PROMPT, buildKeywordGenPrompt } from '@/lib/ai/prompts';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { productName, productDescription, targetAudience } = body;
+
+    if (!productName || !productDescription) {
+      return NextResponse.json(
+        { error: 'productName and productDescription are required' },
+        { status: 400 }
+      );
+    }
+
+    const client = getAnthropicClient();
+    const prompt = buildKeywordGenPrompt(productName, productDescription, targetAudience || null);
+
+    const message = await client.messages.create({
+      model: AI_MODEL,
+      max_tokens: MAX_TOKENS,
+      system: KEYWORD_GEN_SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const textContent = message.content.find((c) => c.type === 'text');
+    if (!textContent || textContent.type !== 'text') {
+      return NextResponse.json({ error: 'No response from AI' }, { status: 500 });
+    }
+
+    let responseText = textContent.text.trim();
+    if (responseText.startsWith('```')) {
+      responseText = responseText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+    }
+
+    const parsed = JSON.parse(responseText) as { keywords: string[] };
+    return NextResponse.json({ keywords: parsed.keywords });
+  } catch (error) {
+    console.error('Keyword generation error:', error);
+    return NextResponse.json({ error: 'Failed to generate keywords' }, { status: 500 });
+  }
+}

--- a/app/src/app/api/outreach/replies/route.ts
+++ b/app/src/app/api/outreach/replies/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function GET(request: NextRequest) {
+  try {
+    const projectId = request.nextUrl.searchParams.get('project_id');
+    if (!projectId) {
+      return NextResponse.json({ error: 'project_id is required' }, { status: 400 });
+    }
+
+    const supabase = await createClient();
+    const status = request.nextUrl.searchParams.get('status');
+
+    let query = supabase
+      .from('outreach_replies')
+      .select('*, signal:outreach_signals(title, subreddit, permalink)')
+      .eq('project_id', projectId)
+      .order('created_at', { ascending: false });
+
+    if (status && status !== 'all') {
+      query = query.eq('status', status);
+    }
+
+    const { data, error } = await query.limit(50);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ replies: data ?? [] });
+  } catch (error) {
+    console.error('Replies fetch error:', error);
+    return NextResponse.json({ error: 'Failed to fetch replies' }, { status: 500 });
+  }
+}

--- a/app/src/app/api/outreach/reply/copied/route.ts
+++ b/app/src/app/api/outreach/reply/copied/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { reply_id, signal_id } = body;
+
+    if (!reply_id) {
+      return NextResponse.json({ error: 'reply_id is required' }, { status: 400 });
+    }
+
+    const supabase = await createClient();
+
+    // Mark reply as copied
+    const { error: replyError } = await supabase
+      .from('outreach_replies')
+      .update({ status: 'copied' })
+      .eq('id', reply_id);
+
+    if (replyError) {
+      return NextResponse.json({ error: replyError.message }, { status: 500 });
+    }
+
+    // Mark signal as replied
+    if (signal_id) {
+      await supabase
+        .from('outreach_signals')
+        .update({ status: 'replied' })
+        .eq('id', signal_id);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Reply copied error:', error);
+    return NextResponse.json({ error: 'Failed to mark reply as copied' }, { status: 500 });
+  }
+}

--- a/app/src/app/api/outreach/setup/route.ts
+++ b/app/src/app/api/outreach/setup/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { project_id, keywords, competitors, reddit_username } = body;
+
+    if (!project_id) {
+      return NextResponse.json({ error: 'project_id is required' }, { status: 400 });
+    }
+
+    const supabase = await createClient();
+
+    const { data, error } = await supabase
+      .from('outreach_configs')
+      .upsert(
+        {
+          project_id,
+          keywords: keywords || [],
+          competitors: competitors || [],
+          reddit_username: reddit_username || null,
+          setup_completed: true,
+        },
+        { onConflict: 'project_id' }
+      )
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ config: data });
+  } catch (error) {
+    console.error('Outreach setup error:', error);
+    return NextResponse.json({ error: 'Failed to save outreach config' }, { status: 500 });
+  }
+}

--- a/app/src/app/api/outreach/signals/route.ts
+++ b/app/src/app/api/outreach/signals/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { detectSignals } from '@/lib/outreach/detector';
+
+export async function GET(request: NextRequest) {
+  try {
+    const projectId = request.nextUrl.searchParams.get('project_id');
+    if (!projectId) {
+      return NextResponse.json({ error: 'project_id is required' }, { status: 400 });
+    }
+
+    const supabase = await createClient();
+
+    // Get outreach config
+    const { data: config } = await supabase
+      .from('outreach_configs')
+      .select('*')
+      .eq('project_id', projectId)
+      .single();
+
+    if (!config?.setup_completed) {
+      return NextResponse.json({ error: 'Outreach setup not completed' }, { status: 400 });
+    }
+
+    // Check if we need to detect new signals (if none exist or latest is older than 30 min)
+    const { data: latestSignal } = await supabase
+      .from('outreach_signals')
+      .select('fetched_at')
+      .eq('project_id', projectId)
+      .order('fetched_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const staleThreshold = 30 * 60 * 1000; // 30 minutes
+    const isStale = !latestSignal ||
+      Date.now() - new Date(latestSignal.fetched_at).getTime() > staleThreshold;
+
+    if (isStale) {
+      // Get project info for product context
+      const { data: project } = await supabase
+        .from('projects')
+        .select('product_name, product_description')
+        .eq('id', projectId)
+        .single();
+
+      // Get project subreddits
+      const { data: subreddits } = await supabase
+        .from('subreddits')
+        .select('name')
+        .eq('project_id', projectId);
+
+      const subNames = subreddits?.map((s) => s.name) || [];
+
+      if (project && subNames.length > 0) {
+        await detectSignals(supabase, {
+          projectId,
+          keywords: config.keywords || [],
+          competitors: config.competitors || [],
+          subreddits: subNames,
+          subredditLimit: config.subreddit_limit || 20,
+          productName: project.product_name,
+          productDescription: project.product_description,
+        });
+      }
+    }
+
+    // Fetch all signals sorted by combined score
+    const status = request.nextUrl.searchParams.get('status');
+    const intentType = request.nextUrl.searchParams.get('intent_type');
+    const subredditFilter = request.nextUrl.searchParams.get('subreddit');
+
+    let query = supabase
+      .from('outreach_signals')
+      .select('*')
+      .eq('project_id', projectId)
+      .order('combined_score', { ascending: false });
+
+    if (status) {
+      query = query.eq('status', status);
+    }
+    if (intentType) {
+      query = query.eq('intent_type', intentType);
+    }
+    if (subredditFilter) {
+      query = query.eq('subreddit', subredditFilter);
+    }
+
+    const { data: signals, error } = await query.limit(50);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ signals: signals || [] });
+  } catch (error) {
+    console.error('Signals fetch error:', error);
+    return NextResponse.json({ error: 'Failed to fetch signals' }, { status: 500 });
+  }
+}

--- a/app/src/app/api/outreach/signals/status/route.ts
+++ b/app/src/app/api/outreach/signals/status/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { signal_id, status } = body;
+
+    if (!signal_id || !status) {
+      return NextResponse.json({ error: 'signal_id and status are required' }, { status: 400 });
+    }
+
+    const validStatuses = ['new', 'replied', 'dismissed', 'converted'];
+    if (!validStatuses.includes(status)) {
+      return NextResponse.json({ error: 'Invalid status' }, { status: 400 });
+    }
+
+    const supabase = await createClient();
+    const { error } = await supabase
+      .from('outreach_signals')
+      .update({ status })
+      .eq('id', signal_id);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Signal status update error:', error);
+    return NextResponse.json({ error: 'Failed to update signal status' }, { status: 500 });
+  }
+}

--- a/app/src/app/api/reddit/subreddit-rules/route.ts
+++ b/app/src/app/api/reddit/subreddit-rules/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServiceClient } from '@/lib/supabase/server';
+import { parseComplianceProfile, computeSafetyScore } from '@/lib/outreach/compliance';
+
+const USER_AGENT = 'web:superreddit:v1.0.0 (by /u/superreddit_app)';
+const REDDIT_BASE = 'https://www.reddit.com';
+
+export async function GET(request: NextRequest) {
+  try {
+    const subreddit = request.nextUrl.searchParams.get('subreddit');
+    if (!subreddit) {
+      return NextResponse.json({ error: 'subreddit is required' }, { status: 400 });
+    }
+
+    const supabase = await createServiceClient();
+
+    // Check cache first
+    const { data: cached } = await supabase
+      .from('subreddit_rules')
+      .select('*')
+      .eq('subreddit', subreddit)
+      .maybeSingle();
+
+    // Return cached if analyzed within last 24h
+    if (cached && cached.analyzed_at) {
+      const age = Date.now() - new Date(cached.analyzed_at).getTime();
+      if (age < 24 * 60 * 60 * 1000) {
+        return NextResponse.json({ rules: cached });
+      }
+    }
+
+    // Fetch rules from Reddit
+    const url = `${REDDIT_BASE}/r/${subreddit}/about/rules.json`;
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': USER_AGENT,
+        'Accept': 'application/json',
+      },
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `Failed to fetch rules for r/${subreddit}` },
+        { status: response.status }
+      );
+    }
+
+    const json = await response.json() as { rules?: Record<string, unknown>[] };
+    const rulesJson = json.rules || [];
+    const complianceProfile = parseComplianceProfile(rulesJson);
+    const safetyScore = computeSafetyScore(complianceProfile);
+
+    // Upsert to cache
+    const { data: saved, error } = await supabase
+      .from('subreddit_rules')
+      .upsert(
+        {
+          subreddit,
+          rules_json: rulesJson,
+          compliance_profile: complianceProfile,
+          safety_score: safetyScore,
+          analyzed_at: new Date().toISOString(),
+        },
+        { onConflict: 'subreddit' }
+      )
+      .select()
+      .single();
+
+    if (error) {
+      // Still return the data even if cache save failed
+      return NextResponse.json({
+        rules: {
+          subreddit,
+          rules_json: rulesJson,
+          compliance_profile: complianceProfile,
+          safety_score: safetyScore,
+        },
+      });
+    }
+
+    return NextResponse.json({ rules: saved });
+  } catch (error) {
+    console.error('Subreddit rules error:', error);
+    return NextResponse.json({ error: 'Failed to fetch subreddit rules' }, { status: 500 });
+  }
+}

--- a/app/src/app/projects/[id]/outreach/competitors/page.tsx
+++ b/app/src/app/projects/[id]/outreach/competitors/page.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { TrendingUp, TrendingDown, MessageSquare, ExternalLink, AlertCircle, ArrowUpRight, Clock } from 'lucide-react';
+import { motion } from 'motion/react';
+import { useProject } from '@/contexts/project-context';
+import { PageTransition, StaggerList, StaggerItem } from '@/components/motion';
+import { Header } from '@/components/layout/header';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cardHover, cardTap } from '@/lib/motion';
+import { toast } from 'sonner';
+import type { OutreachSignal, OutreachConfig } from '@/types';
+
+interface CompetitorSummary {
+  name: string;
+  mentions: number;
+  topIntent: string;
+}
+
+type CompFilter = 'all' | string;
+
+const intentColors: Record<string, string> = {
+  question: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300',
+  comparison: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300',
+  problem: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300',
+  discussion: 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-300',
+  showcase: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300',
+};
+
+function timeAgo(utc: number) {
+  const seconds = Math.floor(Date.now() / 1000 - utc);
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`;
+  return new Date(utc * 1000).toLocaleDateString();
+}
+
+function matchCompetitor(signal: OutreachSignal, competitors: string[]): string | null {
+  const text = `${signal.title} ${signal.body ?? ''}`.toLowerCase();
+  for (const comp of competitors) {
+    if (text.includes(comp.toLowerCase())) return comp;
+  }
+  return null;
+}
+
+export default function OutreachCompetitorsPage() {
+  const project = useProject();
+  const [config, setConfig] = useState<OutreachConfig | null>(null);
+  const [signals, setSignals] = useState<OutreachSignal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [compFilter, setCompFilter] = useState<CompFilter>('all');
+
+  // Fetch config + competitor signals
+  useEffect(() => {
+    async function load() {
+      setLoading(true);
+      try {
+        // Fetch config for competitor names
+        const configRes = await fetch(`/api/outreach/config?project_id=${project.id}`);
+        const configJson = await configRes.json();
+        const cfg = configJson.config as OutreachConfig | null;
+        setConfig(cfg);
+
+        // Fetch all signals (we'll filter for competitor mentions client-side)
+        const sigRes = await fetch(`/api/outreach/signals?project_id=${project.id}`);
+        const sigJson = await sigRes.json();
+
+        if (sigJson.signals) {
+          // Filter to only competitor-mentioned signals
+          const competitorSignals = (sigJson.signals as OutreachSignal[]).filter(
+            (s) => s.competitor_mentioned
+          );
+          setSignals(competitorSignals);
+        }
+      } catch {
+        toast.error('Failed to load competitor data');
+      }
+      setLoading(false);
+    }
+    load();
+  }, [project.id]);
+
+  const competitors = config?.competitors || [];
+
+  // Build summaries
+  const summaries: CompetitorSummary[] = competitors.map((name) => {
+    const mentions = signals.filter((s) => matchCompetitor(s, [name]) !== null);
+    // Find most common intent type
+    const intentCounts: Record<string, number> = {};
+    mentions.forEach((s) => {
+      if (s.intent_type) intentCounts[s.intent_type] = (intentCounts[s.intent_type] || 0) + 1;
+    });
+    const topIntent = Object.entries(intentCounts).sort((a, b) => b[1] - a[1])[0]?.[0] || 'question';
+    return { name, mentions: mentions.length, topIntent };
+  });
+
+  // Filter signals by selected competitor
+  const filtered = compFilter === 'all'
+    ? signals
+    : signals.filter((s) => matchCompetitor(s, [compFilter]) !== null);
+
+  return (
+    <PageTransition>
+      <div className="flex h-full flex-col">
+        <Header title="Competitor Watch" />
+        <div className="flex-1 overflow-auto">
+          <div className="mx-auto max-w-6xl p-6 space-y-6">
+            {loading ? (
+              <>
+                <div className="grid grid-cols-3 gap-3">
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <Skeleton key={i} className="h-28 rounded-xl" />
+                  ))}
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <Skeleton key={i} className="h-48 rounded-xl" />
+                  ))}
+                </div>
+              </>
+            ) : competitors.length === 0 ? (
+              <div className="py-12 text-center text-muted-foreground">
+                No competitors configured. Add competitors in the Outreach setup to start tracking.
+              </div>
+            ) : (
+              <>
+                {/* Competitor summary cards */}
+                <div className="grid grid-cols-3 gap-3">
+                  {summaries.map((comp) => (
+                    <Card
+                      key={comp.name}
+                      className={`cursor-pointer transition-shadow hover:shadow-md ${compFilter === comp.name ? 'ring-2 ring-primary' : ''}`}
+                      onClick={() => setCompFilter(compFilter === comp.name ? 'all' : comp.name)}
+                    >
+                      <CardContent className="p-4 space-y-2">
+                        <div className="flex items-center justify-between">
+                          <p className="font-semibold text-sm">{comp.name}</p>
+                          <Badge variant="secondary" className={intentColors[comp.topIntent] || intentColors.discussion}>
+                            {comp.topIntent}
+                          </Badge>
+                        </div>
+                        <p className="text-2xl font-bold">{comp.mentions}</p>
+                        <p className="text-[11px] text-muted-foreground">mentions found</p>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+
+                {/* Filter tabs */}
+                <div className="flex items-center gap-2">
+                  <Tabs value={compFilter} onValueChange={(v) => setCompFilter(v)}>
+                    <TabsList className="h-8">
+                      <TabsTrigger value="all" className="text-xs px-3 h-6">All</TabsTrigger>
+                      {competitors.map((c) => (
+                        <TabsTrigger key={c} value={c} className="text-xs px-3 h-6">
+                          {c}
+                        </TabsTrigger>
+                      ))}
+                    </TabsList>
+                  </Tabs>
+                </div>
+
+                {/* Mention header */}
+                <div className="flex items-center gap-2">
+                  <h2 className="text-lg font-semibold">Mentions</h2>
+                  <span className="text-sm text-muted-foreground">
+                    {filtered.length} posts
+                  </span>
+                </div>
+
+                {/* Mention cards — 3-column grid */}
+                {filtered.length === 0 ? (
+                  <div className="py-12 text-center text-muted-foreground">
+                    No competitor mentions found yet. Signals are checked periodically.
+                  </div>
+                ) : (
+                  <StaggerList className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                    {filtered.map((signal) => {
+                      const comp = matchCompetitor(signal, competitors) || 'Unknown';
+                      return (
+                        <StaggerItem key={signal.id}>
+                          <motion.div whileHover={cardHover} whileTap={cardTap} className="h-full">
+                            <Card className="transition-shadow hover:shadow-md h-full flex flex-col">
+                              <CardContent className="p-4 flex flex-col flex-1 space-y-2.5">
+                                {/* Top row: competitor + intent + subreddit */}
+                                <div className="flex items-center gap-1.5 flex-wrap">
+                                  <Badge
+                                    variant="secondary"
+                                    className="text-[10px] px-1.5 py-0 bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300"
+                                  >
+                                    {comp}
+                                  </Badge>
+                                  {signal.intent_type && (
+                                    <Badge
+                                      variant="secondary"
+                                      className={`text-[10px] px-1.5 py-0 ${intentColors[signal.intent_type] || intentColors.discussion}`}
+                                    >
+                                      {signal.intent_type}
+                                    </Badge>
+                                  )}
+                                  <span className="text-[11px] text-muted-foreground">r/{signal.subreddit}</span>
+                                </div>
+
+                                {/* Title */}
+                                <a
+                                  href={`https://reddit.com${signal.permalink}`}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="hover:underline"
+                                >
+                                  <h3 className="font-medium text-sm leading-snug line-clamp-2">{signal.title}</h3>
+                                </a>
+
+                                {/* Body preview */}
+                                {signal.body && (
+                                  <p className="text-xs text-muted-foreground line-clamp-3">
+                                    {signal.body}
+                                  </p>
+                                )}
+
+                                {/* Spacer */}
+                                <div className="flex-1" />
+
+                                {/* Meta row */}
+                                <div className="flex items-center gap-2 text-[11px] text-muted-foreground flex-wrap">
+                                  <span className="flex items-center gap-0.5">
+                                    <ArrowUpRight className="h-3 w-3 text-orange-500" />
+                                    {signal.score}
+                                  </span>
+                                  <span className="flex items-center gap-0.5">
+                                    <MessageSquare className="h-3 w-3" />
+                                    {signal.num_comments}
+                                  </span>
+                                  <span className="flex items-center gap-0.5">
+                                    <Clock className="h-3 w-3" />
+                                    {timeAgo(signal.created_utc)}
+                                  </span>
+                                  <span>u/{signal.author}</span>
+                                </div>
+
+                                {/* Action */}
+                                <div className="flex items-center gap-1 pt-0.5">
+                                  <a
+                                    href={`https://reddit.com${signal.permalink}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                  >
+                                    <Button variant="ghost" size="sm" className="h-6 text-[11px] px-2">
+                                      <ExternalLink className="mr-1 h-3 w-3" />
+                                      View Thread
+                                    </Button>
+                                  </a>
+                                </div>
+                              </CardContent>
+                            </Card>
+                          </motion.div>
+                        </StaggerItem>
+                      );
+                    })}
+                  </StaggerList>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </PageTransition>
+  );
+}

--- a/app/src/app/projects/[id]/outreach/layout.tsx
+++ b/app/src/app/projects/[id]/outreach/layout.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { Loader2, Target, ArrowRight, SkipForward } from 'lucide-react';
+import { useProject } from '@/contexts/project-context';
+import { Button } from '@/components/ui/button';
+
+export default function OutreachLayout({ children }: { children: React.ReactNode }) {
+  const project = useProject();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const [checking, setChecking] = useState(true);
+  const [setupDone, setSetupDone] = useState(false);
+  const [skipped, setSkipped] = useState(false);
+
+  const isSetupPage = pathname.endsWith('/setup');
+
+  useEffect(() => {
+    // Don't gate the setup page itself
+    if (isSetupPage) {
+      setChecking(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function check() {
+      try {
+        const res = await fetch(`/api/outreach/config?project_id=${project.id}`);
+        const json = await res.json();
+        if (!cancelled) {
+          setSetupDone(json.config?.setup_completed === true);
+        }
+      } catch {
+        // If API fails (e.g. DB tables missing), allow skip
+        if (!cancelled) setSetupDone(false);
+      } finally {
+        if (!cancelled) setChecking(false);
+      }
+    }
+
+    check();
+    return () => { cancelled = true; };
+  }, [project.id, isSetupPage]);
+
+  // Setup page always renders directly
+  if (isSetupPage) return <>{children}</>;
+
+  // Loading state
+  if (checking) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  // Setup complete or user skipped — render the page
+  if (setupDone || skipped) return <>{children}</>;
+
+  // Setup not complete — show prompt with skip option
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="max-w-sm space-y-4 text-center">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+          <Target className="h-6 w-6 text-primary" />
+        </div>
+        <h2 className="text-lg font-semibold">Set up Outreach</h2>
+        <p className="text-sm text-muted-foreground">
+          Configure keywords and competitors so we can find the right Reddit conversations for {project.product_name}.
+        </p>
+        <div className="flex flex-col gap-2">
+          <Button onClick={() => router.push(`/projects/${project.id}/outreach/setup`)}>
+            Start Setup
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => setSkipped(true)}>
+            <SkipForward className="mr-1.5 h-3.5 w-3.5" />
+            Skip for now
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/app/projects/[id]/outreach/page.tsx
+++ b/app/src/app/projects/[id]/outreach/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useProject } from '@/contexts/project-context';
+
+export default function OutreachPage() {
+  const project = useProject();
+  const router = useRouter();
+
+  // Layout already verified setup is complete, so go straight to signals
+  useEffect(() => {
+    router.replace(`/projects/${project.id}/outreach/signals`);
+  }, [project.id, router]);
+
+  return null;
+}

--- a/app/src/app/projects/[id]/outreach/setup/page.tsx
+++ b/app/src/app/projects/[id]/outreach/setup/page.tsx
@@ -1,0 +1,404 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { AnimatePresence, motion } from 'motion/react';
+import { Loader2, Sparkles, Plus, X, ArrowRight, ArrowLeft, Target, Radio, MessageSquare } from 'lucide-react';
+import { useProject } from '@/contexts/project-context';
+import { PageTransition } from '@/components/motion';
+import { Header } from '@/components/layout/header';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import { slideHorizontalVariants } from '@/lib/motion';
+import { toast } from 'sonner';
+
+const STEPS = ['Welcome', 'Keywords', 'Competitors', 'Finish'];
+
+export default function OutreachSetupPage() {
+  const project = useProject();
+  const router = useRouter();
+
+  const [step, setStep] = useState(0);
+  const directionRef = useRef(1);
+
+  // Step 2: Keywords
+  const [keywords, setKeywords] = useState<string[]>([]);
+  const [keywordInput, setKeywordInput] = useState('');
+  const [generatingKeywords, setGeneratingKeywords] = useState(false);
+
+  // Step 3: Competitors
+  const [competitors, setCompetitors] = useState<string[]>([]);
+  const [competitorInput, setCompetitorInput] = useState('');
+
+  // Step 4: Username + finish
+  const [redditUsername, setRedditUsername] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  function goToStep(next: number) {
+    directionRef.current = next > step ? 1 : -1;
+    setStep(next);
+  }
+
+  async function handleGenerateKeywords() {
+    setGeneratingKeywords(true);
+    try {
+      const res = await fetch('/api/outreach/keywords/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          productName: project.product_name,
+          productDescription: project.product_description,
+          targetAudience: project.target_audience,
+        }),
+      });
+
+      const json = await res.json();
+      if (json.error) {
+        toast.error(json.error);
+      } else {
+        setKeywords(json.keywords || []);
+        toast.success(`Generated ${json.keywords?.length || 0} keywords`);
+      }
+    } catch {
+      toast.error('Failed to generate keywords');
+    }
+    setGeneratingKeywords(false);
+  }
+
+  function addKeyword() {
+    const kw = keywordInput.trim();
+    if (kw && !keywords.includes(kw)) {
+      setKeywords([...keywords, kw]);
+      setKeywordInput('');
+    }
+  }
+
+  function removeKeyword(kw: string) {
+    setKeywords(keywords.filter((k) => k !== kw));
+  }
+
+  function addCompetitor() {
+    const comp = competitorInput.trim();
+    if (comp && !competitors.includes(comp)) {
+      setCompetitors([...competitors, comp]);
+      setCompetitorInput('');
+    }
+  }
+
+  function removeCompetitor(comp: string) {
+    setCompetitors(competitors.filter((c) => c !== comp));
+  }
+
+  async function handleFinish() {
+    if (keywords.length === 0) {
+      toast.error('Add at least one keyword');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const res = await fetch('/api/outreach/setup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          project_id: project.id,
+          keywords,
+          competitors,
+          reddit_username: redditUsername || null,
+        }),
+      });
+
+      const json = await res.json();
+      if (json.error) {
+        toast.error(json.error);
+      } else {
+        toast.success('Outreach setup complete!');
+        router.replace(`/projects/${project.id}/outreach/signals`);
+      }
+    } catch {
+      toast.error('Failed to save setup');
+    }
+    setSaving(false);
+  }
+
+  return (
+    <PageTransition>
+      <div className="flex h-full flex-col">
+        <Header title="Outreach Setup" />
+        <div className="flex-1 overflow-auto">
+          <div className="mx-auto max-w-2xl p-6 space-y-6">
+            {/* Step indicator */}
+            <div className="flex items-center justify-center gap-2">
+              {STEPS.map((label, s) => (
+                <div key={label} className="flex items-center gap-2">
+                  <div
+                    className={`flex h-8 w-8 items-center justify-center rounded-full text-xs font-semibold transition-colors ${
+                      s === step
+                        ? 'bg-primary text-primary-foreground'
+                        : s < step
+                          ? 'bg-primary/20 text-primary'
+                          : 'bg-muted text-muted-foreground'
+                    }`}
+                  >
+                    {s + 1}
+                  </div>
+                  {s < STEPS.length - 1 && (
+                    <div className={`h-px w-8 ${s < step ? 'bg-primary/40' : 'bg-muted'}`} />
+                  )}
+                </div>
+              ))}
+            </div>
+
+            <AnimatePresence mode="wait" custom={directionRef.current}>
+              <motion.div
+                key={step}
+                custom={directionRef.current}
+                variants={slideHorizontalVariants}
+                initial="enter"
+                animate="center"
+                exit="exit"
+              >
+                {/* Step 0: Welcome / Intro */}
+                {step === 0 && (
+                  <div className="space-y-6">
+                    <div className="text-center space-y-2">
+                      <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
+                        <Target className="h-7 w-7 text-primary" />
+                      </div>
+                      <h2 className="text-xl font-semibold">Set up Outreach for {project.product_name}</h2>
+                      <p className="text-sm text-muted-foreground max-w-md mx-auto">
+                        Outreach scans Reddit for conversations where people are looking for
+                        exactly what you offer — then helps you reply naturally.
+                      </p>
+                    </div>
+
+                    <div className="grid gap-3">
+                      <Card>
+                        <CardContent className="flex items-start gap-3 p-4">
+                          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-500/10">
+                            <Radio className="h-4 w-4 text-blue-500" />
+                          </div>
+                          <div>
+                            <p className="text-sm font-medium">Find signals</p>
+                            <p className="text-xs text-muted-foreground">
+                              We search your target subreddits for posts matching your keywords — questions,
+                              comparisons, and pain points where {project.product_name} is relevant.
+                            </p>
+                          </div>
+                        </CardContent>
+                      </Card>
+                      <Card>
+                        <CardContent className="flex items-start gap-3 p-4">
+                          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-purple-500/10">
+                            <Sparkles className="h-4 w-4 text-purple-500" />
+                          </div>
+                          <div>
+                            <p className="text-sm font-medium">AI scores & classifies</p>
+                            <p className="text-xs text-muted-foreground">
+                              Each signal gets an intent score and type (question, comparison, problem) so
+                              you focus on the highest-value conversations first.
+                            </p>
+                          </div>
+                        </CardContent>
+                      </Card>
+                      <Card>
+                        <CardContent className="flex items-start gap-3 p-4">
+                          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-green-500/10">
+                            <MessageSquare className="h-4 w-4 text-green-500" />
+                          </div>
+                          <div>
+                            <p className="text-sm font-medium">Draft & reply</p>
+                            <p className="text-xs text-muted-foreground">
+                              Generate authentic replies that mention your product naturally, respect
+                              subreddit rules, and sound like a real person — not a marketer.
+                            </p>
+                          </div>
+                        </CardContent>
+                      </Card>
+                    </div>
+
+                    <p className="text-center text-xs text-muted-foreground">
+                      Takes about 1 minute to set up. We&apos;ll use your existing product info to get started.
+                    </p>
+
+                    <div className="flex justify-center">
+                      <Button onClick={() => goToStep(1)} size="lg">
+                        Get Started
+                        <ArrowRight className="ml-2 h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Step 1: Keywords */}
+                {step === 1 && (
+                  <div className="space-y-4">
+                    <div>
+                      <h2 className="text-lg font-semibold">Search Keywords</h2>
+                      <p className="text-sm text-muted-foreground">
+                        These keywords are used to find Reddit posts where someone might need {project.product_name}.
+                        Think pain points, questions, and &quot;looking for&quot; phrases.
+                      </p>
+                    </div>
+
+                    <Button
+                      onClick={handleGenerateKeywords}
+                      disabled={generatingKeywords}
+                      className="w-full"
+                    >
+                      {generatingKeywords ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      ) : (
+                        <Sparkles className="mr-2 h-4 w-4" />
+                      )}
+                      {generatingKeywords
+                        ? 'Generating...'
+                        : keywords.length > 0
+                          ? 'Regenerate Keywords'
+                          : 'Auto-Generate Keywords from Your Product'}
+                    </Button>
+
+                    <div className="flex gap-2">
+                      <Input
+                        value={keywordInput}
+                        onChange={(e) => setKeywordInput(e.target.value)}
+                        onKeyDown={(e) => e.key === 'Enter' && addKeyword()}
+                        placeholder="Or add manually, e.g. &quot;best tool for...&quot;"
+                      />
+                      <Button variant="outline" onClick={addKeyword}>
+                        <Plus className="h-4 w-4" />
+                      </Button>
+                    </div>
+
+                    {keywords.length > 0 && (
+                      <div className="flex flex-wrap gap-2">
+                        {keywords.map((kw) => (
+                          <Badge key={kw} variant="secondary" className="gap-1 pr-1">
+                            {kw}
+                            <button
+                              onClick={() => removeKeyword(kw)}
+                              className="ml-1 rounded-full p-0.5 hover:bg-muted"
+                            >
+                              <X className="h-3 w-3" />
+                            </button>
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+
+                    <div className="flex justify-between">
+                      <Button variant="outline" onClick={() => goToStep(0)}>
+                        <ArrowLeft className="mr-2 h-4 w-4" />
+                        Back
+                      </Button>
+                      <Button onClick={() => goToStep(2)} disabled={keywords.length === 0}>
+                        Next
+                        <ArrowRight className="ml-2 h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Step 2: Competitors */}
+                {step === 2 && (
+                  <div className="space-y-4">
+                    <div>
+                      <h2 className="text-lg font-semibold">Competitors (optional)</h2>
+                      <p className="text-sm text-muted-foreground">
+                        When someone mentions a competitor by name, that signal gets flagged — great
+                        opportunities to suggest {project.product_name} as an alternative.
+                      </p>
+                    </div>
+
+                    <div className="flex gap-2">
+                      <Input
+                        value={competitorInput}
+                        onChange={(e) => setCompetitorInput(e.target.value)}
+                        onKeyDown={(e) => e.key === 'Enter' && addCompetitor()}
+                        placeholder="e.g. Competitor Inc, RivalApp"
+                      />
+                      <Button variant="outline" onClick={addCompetitor}>
+                        <Plus className="h-4 w-4" />
+                      </Button>
+                    </div>
+
+                    {competitors.length > 0 && (
+                      <div className="flex flex-wrap gap-2">
+                        {competitors.map((comp) => (
+                          <Badge key={comp} variant="secondary" className="gap-1 pr-1">
+                            {comp}
+                            <button
+                              onClick={() => removeCompetitor(comp)}
+                              className="ml-1 rounded-full p-0.5 hover:bg-muted"
+                            >
+                              <X className="h-3 w-3" />
+                            </button>
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+
+                    <div className="flex justify-between">
+                      <Button variant="outline" onClick={() => goToStep(1)}>
+                        <ArrowLeft className="mr-2 h-4 w-4" />
+                        Back
+                      </Button>
+                      <Button onClick={() => goToStep(3)}>
+                        {competitors.length === 0 ? 'Skip' : 'Next'}
+                        <ArrowRight className="ml-2 h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Step 3: Username + Finish */}
+                {step === 3 && (
+                  <div className="space-y-4">
+                    <div>
+                      <h2 className="text-lg font-semibold">Almost done</h2>
+                      <p className="text-sm text-muted-foreground">
+                        Add your Reddit username so we can track replies you post.
+                      </p>
+                    </div>
+
+                    <Input
+                      value={redditUsername}
+                      onChange={(e) => setRedditUsername(e.target.value)}
+                      placeholder="u/your_username"
+                    />
+
+                    <div className="rounded-lg border bg-muted/30 p-4 space-y-3">
+                      <h3 className="font-medium text-sm">Setup Summary</h3>
+                      <div className="space-y-1 text-xs text-muted-foreground">
+                        <p><span className="font-medium text-foreground">{keywords.length}</span> keywords to search for</p>
+                        <p><span className="font-medium text-foreground">{competitors.length}</span> competitors to watch</p>
+                        {redditUsername && <p>Tracking as <span className="font-medium text-foreground">u/{redditUsername}</span></p>}
+                      </div>
+                    </div>
+
+                    <div className="flex justify-between">
+                      <Button variant="outline" onClick={() => goToStep(2)}>
+                        <ArrowLeft className="mr-2 h-4 w-4" />
+                        Back
+                      </Button>
+                      <Button onClick={handleFinish} disabled={saving || !redditUsername.trim()}>
+                        {saving ? (
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        ) : (
+                          <Sparkles className="mr-2 h-4 w-4" />
+                        )}
+                        {saving ? 'Setting up...' : 'Start Finding Signals'}
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </motion.div>
+            </AnimatePresence>
+          </div>
+        </div>
+      </div>
+    </PageTransition>
+  );
+}

--- a/app/src/app/projects/[id]/outreach/signals/page.tsx
+++ b/app/src/app/projects/[id]/outreach/signals/page.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { useProject } from '@/contexts/project-context';
+import { PageTransition, StaggerList, StaggerItem } from '@/components/motion';
+import { Header } from '@/components/layout/header';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { SignalCard } from '@/components/outreach/SignalCard';
+import { toast } from 'sonner';
+import type { OutreachSignal } from '@/types';
+
+type IntentFilter = 'all' | 'question' | 'comparison' | 'problem' | 'discussion' | 'showcase';
+type StatusFilter = 'new' | 'all' | 'replied' | 'dismissed';
+
+export default function OutreachSignalsPage() {
+  const project = useProject();
+  const [signals, setSignals] = useState<OutreachSignal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [intentFilter, setIntentFilter] = useState<IntentFilter>('all');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('new');
+  const [safetyScores, setSafetyScores] = useState<Record<string, number | null>>({});
+
+  const fetchSignals = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ project_id: project.id });
+      if (statusFilter !== 'all') params.set('status', statusFilter);
+      if (intentFilter !== 'all') params.set('intent_type', intentFilter);
+
+      const res = await fetch(`/api/outreach/signals?${params}`);
+      const json = await res.json();
+
+      if (json.error) {
+        toast.error(json.error);
+        setSignals([]);
+      } else {
+        setSignals(json.signals || []);
+      }
+    } catch {
+      toast.error('Failed to load signals');
+      setSignals([]);
+    }
+    setLoading(false);
+  }, [project.id, statusFilter, intentFilter]);
+
+  // Fetch signals on mount and when filters change
+  useEffect(() => {
+    fetchSignals();
+  }, [fetchSignals]);
+
+  // Fetch safety scores for unique subreddits
+  useEffect(() => {
+    if (signals.length === 0) return;
+    const subreddits = [...new Set(signals.map((s) => s.subreddit))] as string[];
+    const missing = subreddits.filter((sub) => !(sub in safetyScores));
+
+    if (missing.length === 0) return;
+
+    missing.forEach(async (sub) => {
+      try {
+        const res = await fetch(`/api/reddit/subreddit-rules?subreddit=${encodeURIComponent(sub)}`);
+        const json = await res.json();
+        if (json.rules?.safety_score != null) {
+          setSafetyScores((prev) => ({ ...prev, [sub]: json.rules.safety_score }));
+        } else {
+          setSafetyScores((prev) => ({ ...prev, [sub]: null }));
+        }
+      } catch {
+        setSafetyScores((prev) => ({ ...prev, [sub]: null }));
+      }
+    });
+  }, [signals, safetyScores]);
+
+  async function handleStatusChange(signalId: string, status: string) {
+    // Optimistic update
+    setSignals((prev) =>
+      prev.map((s) => (s.id === signalId ? { ...s, status: status as OutreachSignal['status'] } : s))
+    );
+
+    try {
+      const res = await fetch('/api/outreach/signals/status', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ signal_id: signalId, status }),
+      });
+      const json = await res.json();
+      if (json.error) {
+        toast.error(json.error);
+        fetchSignals(); // revert by re-fetching
+      } else {
+        toast.success(`Signal marked as ${status}`);
+      }
+    } catch {
+      toast.error('Failed to update signal');
+      fetchSignals();
+    }
+  }
+
+  return (
+    <PageTransition>
+      <div className="flex h-full flex-col">
+        <Header title="Outreach Signals" />
+        <div className="flex-1 overflow-auto">
+          <div className="mx-auto max-w-6xl p-6 space-y-6">
+            {/* Filter bar */}
+            <div className="flex items-center gap-2 flex-wrap">
+              <Tabs value={intentFilter} onValueChange={(v) => setIntentFilter(v as IntentFilter)}>
+                <TabsList className="h-8">
+                  <TabsTrigger value="all" className="text-xs px-3 h-6">All</TabsTrigger>
+                  <TabsTrigger value="question" className="text-xs px-3 h-6">Questions</TabsTrigger>
+                  <TabsTrigger value="comparison" className="text-xs px-3 h-6">Comparisons</TabsTrigger>
+                  <TabsTrigger value="problem" className="text-xs px-3 h-6">Problems</TabsTrigger>
+                  <TabsTrigger value="discussion" className="text-xs px-3 h-6">Discussion</TabsTrigger>
+                </TabsList>
+              </Tabs>
+
+              <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v as StatusFilter)}>
+                <SelectTrigger className="h-8 w-28 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="new">New</SelectItem>
+                  <SelectItem value="all">All</SelectItem>
+                  <SelectItem value="replied">Replied</SelectItem>
+                  <SelectItem value="dismissed">Dismissed</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Stats */}
+            <div className="flex items-center gap-2">
+              <h2 className="text-lg font-semibold">Signals</h2>
+              <span className="text-sm text-muted-foreground">
+                {loading ? '...' : `${signals.length} ${statusFilter !== 'all' ? statusFilter : ''} signals`}
+              </span>
+            </div>
+
+            {/* Signal cards — 3-column grid */}
+            {loading ? (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <Skeleton key={i} className="h-56 rounded-xl" />
+                ))}
+              </div>
+            ) : signals.length === 0 ? (
+              <div className="py-12 text-center text-muted-foreground">
+                No signals found. {statusFilter !== 'all' ? 'Try adjusting filters.' : 'Complete setup and add subreddits to start finding signals.'}
+              </div>
+            ) : (
+              <StaggerList className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                {signals.map((signal) => (
+                  <StaggerItem key={signal.id}>
+                    <SignalCard
+                      signal={signal}
+                      projectId={project.id}
+                      safetyScore={safetyScores[signal.subreddit] ?? null}
+                      onStatusChange={handleStatusChange}
+                    />
+                  </StaggerItem>
+                ))}
+              </StaggerList>
+            )}
+          </div>
+        </div>
+      </div>
+    </PageTransition>
+  );
+}

--- a/app/src/app/projects/[id]/outreach/tracker/page.tsx
+++ b/app/src/app/projects/[id]/outreach/tracker/page.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { ExternalLink, TrendingUp, TrendingDown, Minus, MessageSquare, ArrowUpRight, Clock, CheckCircle2 } from 'lucide-react';
+import { motion } from 'motion/react';
+import { useProject } from '@/contexts/project-context';
+import { PageTransition, StaggerList, StaggerItem } from '@/components/motion';
+import { Header } from '@/components/layout/header';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cardHover, cardTap } from '@/lib/motion';
+import { toast } from 'sonner';
+import type { OutreachReply } from '@/types';
+
+interface ReplyWithSignal extends OutreachReply {
+  signal?: {
+    title: string;
+    subreddit: string;
+    permalink: string;
+  } | null;
+}
+
+type TrackerFilter = 'all' | 'tracking' | 'copied' | 'posted';
+
+function ScoreDelta({ delta }: { delta: number }) {
+  if (delta > 0) return <span className="flex items-center gap-0.5 text-green-500 text-[11px] font-medium"><TrendingUp className="h-3 w-3" />+{delta}</span>;
+  if (delta < 0) return <span className="flex items-center gap-0.5 text-red-500 text-[11px] font-medium"><TrendingDown className="h-3 w-3" />{delta}</span>;
+  return <span className="flex items-center gap-0.5 text-muted-foreground text-[11px]"><Minus className="h-3 w-3" />0</span>;
+}
+
+function timeAgo(dateStr: string | null) {
+  if (!dateStr) return '';
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (seconds < 60) return 'just now';
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`;
+  return new Date(dateStr).toLocaleDateString();
+}
+
+export default function OutreachTrackerPage() {
+  const project = useProject();
+  const [replies, setReplies] = useState<ReplyWithSignal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<TrackerFilter>('all');
+
+  const fetchReplies = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ project_id: project.id });
+      if (filter !== 'all') params.set('status', filter);
+
+      const res = await fetch(`/api/outreach/replies?${params}`);
+      const json = await res.json();
+
+      if (json.error) {
+        toast.error(json.error);
+        setReplies([]);
+      } else {
+        setReplies(json.replies || []);
+      }
+    } catch {
+      toast.error('Failed to load replies');
+      setReplies([]);
+    }
+    setLoading(false);
+  }, [project.id, filter]);
+
+  useEffect(() => {
+    fetchReplies();
+  }, [fetchReplies]);
+
+  // Stats (computed from all replies, not just filtered)
+  const [allReplies, setAllReplies] = useState<ReplyWithSignal[]>([]);
+
+  useEffect(() => {
+    async function fetchAll() {
+      try {
+        const res = await fetch(`/api/outreach/replies?project_id=${project.id}`);
+        const json = await res.json();
+        if (json.replies) setAllReplies(json.replies);
+      } catch { /* stats will show 0 */ }
+    }
+    fetchAll();
+  }, [project.id]);
+
+  const totalTracking = allReplies.filter((r) => r.status === 'tracking' || r.status === 'posted').length;
+  const totalScore = allReplies.reduce((sum, r) => sum + (r.current_score ?? 0), 0);
+  const opRepliedCount = allReplies.filter((r) => r.op_replied).length;
+
+  return (
+    <PageTransition>
+      <div className="flex h-full flex-col">
+        <Header title="Reply Tracker" />
+        <div className="flex-1 overflow-auto">
+          <div className="mx-auto max-w-6xl p-6 space-y-6">
+            {/* Stats row */}
+            <div className="grid grid-cols-3 gap-3">
+              <Card>
+                <CardContent className="p-4 text-center">
+                  <p className="text-2xl font-bold">{totalTracking}</p>
+                  <p className="text-xs text-muted-foreground">Replies Posted</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-4 text-center">
+                  <p className="text-2xl font-bold">{totalScore}</p>
+                  <p className="text-xs text-muted-foreground">Total Upvotes</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-4 text-center">
+                  <p className="text-2xl font-bold">{opRepliedCount}</p>
+                  <p className="text-xs text-muted-foreground">OP Replied</p>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Filter */}
+            <div className="flex items-center gap-2">
+              <Tabs value={filter} onValueChange={(v) => setFilter(v as TrackerFilter)}>
+                <TabsList className="h-8">
+                  <TabsTrigger value="all" className="text-xs px-3 h-6">All</TabsTrigger>
+                  <TabsTrigger value="tracking" className="text-xs px-3 h-6">Tracking</TabsTrigger>
+                  <TabsTrigger value="copied" className="text-xs px-3 h-6">Copied</TabsTrigger>
+                  <TabsTrigger value="posted" className="text-xs px-3 h-6">Posted</TabsTrigger>
+                </TabsList>
+              </Tabs>
+            </div>
+
+            {/* Reply cards — 3-column grid */}
+            {loading ? (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-48 rounded-xl" />
+                ))}
+              </div>
+            ) : replies.length === 0 ? (
+              <div className="py-12 text-center text-muted-foreground">
+                No replies yet. Draft replies from the Signals page to start tracking.
+              </div>
+            ) : (
+              <StaggerList className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                {replies.map((reply) => {
+                  const title = reply.signal?.title || 'Untitled thread';
+                  const subreddit = reply.signal?.subreddit || '';
+                  const permalink = reply.signal?.permalink || reply.thread_permalink || '';
+                  const statusColor = reply.status === 'tracking' || reply.status === 'posted'
+                    ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300'
+                    : 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-300';
+
+                  return (
+                    <StaggerItem key={reply.id}>
+                      <motion.div whileHover={cardHover} whileTap={cardTap} className="h-full">
+                        <Card className="transition-shadow hover:shadow-md h-full flex flex-col">
+                          <CardContent className="p-4 flex flex-col flex-1 space-y-2.5">
+                            {/* Top row: status + subreddit */}
+                            <div className="flex items-center gap-1.5">
+                              <Badge variant="secondary" className={`text-[10px] px-1.5 py-0 ${statusColor}`}>
+                                {reply.status}
+                              </Badge>
+                              {subreddit && (
+                                <span className="text-[11px] text-muted-foreground">r/{subreddit}</span>
+                              )}
+                              {reply.op_replied && (
+                                <span className="flex items-center gap-0.5 text-[11px] text-green-600 ml-auto">
+                                  <CheckCircle2 className="h-3 w-3" />
+                                  OP replied
+                                </span>
+                              )}
+                            </div>
+
+                            {/* Title */}
+                            {permalink ? (
+                              <a
+                                href={`https://reddit.com${permalink}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="hover:underline"
+                              >
+                                <h3 className="font-medium text-sm leading-snug line-clamp-2">{title}</h3>
+                              </a>
+                            ) : (
+                              <h3 className="font-medium text-sm leading-snug line-clamp-2">{title}</h3>
+                            )}
+
+                            {/* Draft preview */}
+                            {reply.draft_text && (
+                              <p className="text-xs text-muted-foreground line-clamp-3">
+                                {reply.draft_text}
+                              </p>
+                            )}
+
+                            {/* Spacer */}
+                            <div className="flex-1" />
+
+                            {/* Meta row */}
+                            <div className="flex items-center gap-2 text-[11px] text-muted-foreground flex-wrap">
+                              <span className="flex items-center gap-0.5">
+                                <ArrowUpRight className="h-3 w-3 text-orange-500" />
+                                {reply.current_score ?? 0}
+                              </span>
+                              <ScoreDelta delta={0} />
+                              <span className="flex items-center gap-0.5">
+                                <MessageSquare className="h-3 w-3" />
+                                {reply.reply_count}
+                              </span>
+                              {reply.posted_at && (
+                                <span className="flex items-center gap-0.5">
+                                  <Clock className="h-3 w-3" />
+                                  {timeAgo(reply.posted_at)}
+                                </span>
+                              )}
+                            </div>
+
+                            {/* Action */}
+                            {permalink && (
+                              <div className="flex items-center gap-1 pt-0.5">
+                                <a
+                                  href={`https://reddit.com${permalink}`}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                >
+                                  <Button variant="ghost" size="sm" className="h-6 text-[11px] px-2">
+                                    <ExternalLink className="mr-1 h-3 w-3" />
+                                    View Thread
+                                  </Button>
+                                </a>
+                              </div>
+                            )}
+                          </CardContent>
+                        </Card>
+                      </motion.div>
+                    </StaggerItem>
+                  );
+                })}
+              </StaggerList>
+            )}
+          </div>
+        </div>
+      </div>
+    </PageTransition>
+  );
+}

--- a/app/src/components/layout/project-sidebar.tsx
+++ b/app/src/components/layout/project-sidebar.tsx
@@ -16,6 +16,10 @@ import {
   Bookmark,
   Scissors,
   LogOut,
+  Target,
+  Radio,
+  BarChart3,
+  Users,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { createClient } from '@/lib/supabase/client';
@@ -29,6 +33,7 @@ export function ProjectSidebar({ project }: { project: Project }) {
   const router = useRouter();
   const base = `/projects/${project.id}`;
   const [createExpanded, setCreateExpanded] = useState(true);
+  const [outreachExpanded, setOutreachExpanded] = useState(true);
 
   const topItems = [
     { href: base, label: 'Dashboard', icon: LayoutDashboard, exact: true },
@@ -40,6 +45,12 @@ export function ProjectSidebar({ project }: { project: Project }) {
     { href: `${base}/daily-mix`, label: 'Your Feed', icon: Shuffle },
     { href: `${base}/chat`, label: 'AI Chat', icon: MessageSquare },
     { href: `${base}/viral-library`, label: 'Viral Library', icon: Library },
+  ];
+
+  const outreachChildren = [
+    { href: `${base}/outreach/signals`, label: 'Signals', icon: Radio },
+    { href: `${base}/outreach/tracker`, label: 'Tracker', icon: BarChart3 },
+    { href: `${base}/outreach/competitors`, label: 'Competitors', icon: Users },
   ];
 
   const bottomItems = [
@@ -134,6 +145,58 @@ export function ProjectSidebar({ project }: { project: Project }) {
             >
               <div className="space-y-1">
                 {createChildren.map((item) => {
+                  const isActive = pathname.startsWith(item.href);
+                  return (
+                    <div key={item.href}>
+                      <Link
+                        href={item.href}
+                        className={cn(
+                          'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors pl-9',
+                          isActive
+                            ? 'bg-primary text-primary-foreground'
+                            : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+                        )}
+                      >
+                        <item.icon className="h-4 w-4" />
+                        {item.label}
+                      </Link>
+                    </div>
+                  );
+                })}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Outreach section */}
+        <motion.div variants={staggerItemVariants}>
+          <button
+            onClick={() => setOutreachExpanded((prev) => !prev)}
+            className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            <Target className="h-4 w-4" />
+            Outreach
+            <ChevronDown
+              className={cn(
+                'ml-auto h-4 w-4 transition-transform duration-200',
+                !outreachExpanded && '-rotate-90'
+              )}
+            />
+          </button>
+        </motion.div>
+
+        <AnimatePresence initial={false}>
+          {outreachExpanded && (
+            <motion.div
+              key="outreach-children"
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.2, ease: 'easeInOut' }}
+              style={{ overflow: 'hidden' }}
+            >
+              <div className="space-y-1">
+                {outreachChildren.map((item) => {
                   const isActive = pathname.startsWith(item.href);
                   return (
                     <div key={item.href}>

--- a/app/src/components/outreach/ComplianceBadge.tsx
+++ b/app/src/components/outreach/ComplianceBadge.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import type { SafetyLevel } from '@/lib/outreach/compliance';
+
+const config: Record<SafetyLevel, { label: string; color: string; dot: string }> = {
+  safe: { label: 'Safe', color: 'text-green-600', dot: 'bg-green-500' },
+  caution: { label: 'Caution', color: 'text-yellow-600', dot: 'bg-yellow-500' },
+  strict: { label: 'Strict', color: 'text-red-600', dot: 'bg-red-500' },
+};
+
+interface ComplianceBadgeProps {
+  level: SafetyLevel;
+  className?: string;
+}
+
+export function ComplianceBadge({ level, className }: ComplianceBadgeProps) {
+  const { label, color, dot } = config[level];
+
+  return (
+    <span className={cn('inline-flex items-center gap-1 text-[10px] font-medium', color, className)}>
+      <span className={cn('h-1.5 w-1.5 rounded-full', dot)} />
+      {label}
+    </span>
+  );
+}

--- a/app/src/components/outreach/ReplyBuilder.tsx
+++ b/app/src/components/outreach/ReplyBuilder.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2, Copy, ExternalLink, Sparkles } from 'lucide-react';
+import { motion } from 'motion/react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { scaleFadeVariants } from '@/lib/motion';
+import { toast } from 'sonner';
+
+interface ReplyBuilderProps {
+  signalId: string;
+  projectId: string;
+  permalink: string;
+  onCopied?: () => void;
+}
+
+type ReplyMode = 'helpful' | 'experience' | 'subtle';
+
+export function ReplyBuilder({ signalId, projectId, permalink, onCopied }: ReplyBuilderProps) {
+  const [mode, setMode] = useState<ReplyMode>('helpful');
+  const [draft, setDraft] = useState('');
+  const [replyId, setReplyId] = useState<string | null>(null);
+  const [generating, setGenerating] = useState(false);
+
+  async function handleGenerate() {
+    setGenerating(true);
+    try {
+      const res = await fetch('/api/ai/outreach-reply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ signal_id: signalId, project_id: projectId, reply_mode: mode }),
+      });
+
+      const json = await res.json();
+      if (json.error) {
+        toast.error(json.error);
+      } else {
+        setDraft(json.reply);
+        if (json.reply_id) setReplyId(json.reply_id);
+        toast.success('Reply draft generated');
+      }
+    } catch {
+      toast.error('Failed to generate reply');
+    }
+    setGenerating(false);
+  }
+
+  async function handleCopyAndOpen() {
+    try {
+      await navigator.clipboard.writeText(draft);
+      toast.success('Reply copied to clipboard');
+
+      // Mark as copied in backend
+      if (replyId) {
+        await fetch('/api/outreach/reply/copied', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ reply_id: replyId, signal_id: signalId }),
+        });
+      }
+
+      onCopied?.();
+
+      // Open Reddit thread
+      window.open(`https://reddit.com${permalink}`, '_blank');
+    } catch {
+      toast.error('Failed to copy to clipboard');
+    }
+  }
+
+  return (
+    <motion.div
+      variants={scaleFadeVariants}
+      initial="hidden"
+      animate="visible"
+      exit="exit"
+      className="mt-3 space-y-3 rounded-lg border bg-muted/30 p-3"
+    >
+      <div className="flex items-center gap-2">
+        <Select value={mode} onValueChange={(v) => setMode(v as ReplyMode)}>
+          <SelectTrigger className="h-8 w-36 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="helpful">Helpful</SelectItem>
+            <SelectItem value="experience">Experience</SelectItem>
+            <SelectItem value="subtle">Subtle</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 text-xs"
+          onClick={handleGenerate}
+          disabled={generating}
+        >
+          {generating ? (
+            <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+          ) : (
+            <Sparkles className="mr-1 h-3 w-3" />
+          )}
+          {generating ? 'Generating...' : 'Generate'}
+        </Button>
+      </div>
+
+      <Textarea
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        placeholder="AI-generated reply will appear here. You can edit it before copying."
+        className="min-h-[100px] text-sm"
+      />
+
+      {draft && (
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            className="h-8 text-xs"
+            onClick={handleCopyAndOpen}
+          >
+            <Copy className="mr-1 h-3 w-3" />
+            Copy & Open Thread
+          </Button>
+          <a
+            href={`https://reddit.com${permalink}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Button variant="ghost" size="sm" className="h-8 text-xs">
+              <ExternalLink className="mr-1 h-3 w-3" />
+              View Thread
+            </Button>
+          </a>
+        </div>
+      )}
+    </motion.div>
+  );
+}

--- a/app/src/components/outreach/SignalCard.tsx
+++ b/app/src/components/outreach/SignalCard.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState } from 'react';
+import { ArrowUpRight, MessageSquare, Clock, ExternalLink, Reply, X } from 'lucide-react';
+import { motion } from 'motion/react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import { cardHover, cardTap } from '@/lib/motion';
+import { ComplianceBadge } from '@/components/outreach/ComplianceBadge';
+import { ReplyBuilder } from '@/components/outreach/ReplyBuilder';
+import { getSafetyLevel } from '@/lib/outreach/compliance';
+import type { OutreachSignal } from '@/types';
+
+interface SignalCardProps {
+  signal: OutreachSignal;
+  projectId: string;
+  safetyScore: number | null;
+  onStatusChange: (signalId: string, status: string) => void;
+}
+
+const intentColors: Record<string, string> = {
+  question: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300',
+  comparison: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300',
+  problem: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300',
+  discussion: 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-300',
+  showcase: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300',
+};
+
+const timeAgo = (timestamp: number) => {
+  const seconds = Math.floor(Date.now() / 1000 - timestamp);
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`;
+  return new Date(timestamp * 1000).toLocaleDateString();
+};
+
+const formatNumber = (n: number) => {
+  if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
+  return n.toString();
+};
+
+export function SignalCard({ signal, projectId, safetyScore, onStatusChange }: SignalCardProps) {
+  const [showReply, setShowReply] = useState(false);
+
+  return (
+    <motion.div whileHover={cardHover} whileTap={cardTap} className="h-full">
+      <Card className="transition-shadow hover:shadow-md h-full flex flex-col">
+        <CardContent className="p-4 flex flex-col flex-1 space-y-2.5">
+          {/* Top row: intent badge + subreddit + safety */}
+          <div className="flex items-center gap-1.5 flex-wrap">
+            {signal.intent_type && (
+              <Badge
+                variant="secondary"
+                className={`text-[10px] px-1.5 py-0 ${intentColors[signal.intent_type] || intentColors.discussion}`}
+              >
+                {signal.intent_type}
+              </Badge>
+            )}
+            <span className="text-[11px] text-muted-foreground">r/{signal.subreddit}</span>
+            <ComplianceBadge level={getSafetyLevel(safetyScore)} />
+            {signal.competitor_mentioned && (
+              <Badge variant="secondary" className="text-[10px] px-1.5 py-0 bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300">
+                competitor
+              </Badge>
+            )}
+          </div>
+
+          {/* Title */}
+          <a
+            href={`https://reddit.com${signal.permalink}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:underline"
+          >
+            <h3 className="font-medium text-sm leading-snug line-clamp-2">{signal.title}</h3>
+          </a>
+
+          {/* Body preview */}
+          {signal.body && (
+            <p className="text-xs text-muted-foreground line-clamp-3">
+              {signal.body}
+            </p>
+          )}
+
+          {/* Matched keywords */}
+          {signal.matched_keywords.length > 0 && (
+            <div className="flex items-center gap-1 flex-wrap">
+              {signal.matched_keywords.map((kw) => (
+                <span
+                  key={kw}
+                  className="inline-flex rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium"
+                >
+                  {kw}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Spacer to push meta + actions to bottom */}
+          <div className="flex-1" />
+
+          {/* Meta row */}
+          <div className="flex items-center gap-2 text-[11px] text-muted-foreground flex-wrap">
+            <span className="flex items-center gap-0.5">
+              <ArrowUpRight className="h-3 w-3 text-orange-500" />
+              {formatNumber(signal.score)}
+            </span>
+            <span className="flex items-center gap-0.5">
+              <MessageSquare className="h-3 w-3" />
+              {formatNumber(signal.num_comments)}
+            </span>
+            <span className="flex items-center gap-0.5">
+              <Clock className="h-3 w-3" />
+              {timeAgo(signal.created_utc)}
+            </span>
+            <span className="ml-auto font-mono text-[10px]">
+              {signal.combined_score.toFixed(2)}
+            </span>
+          </div>
+
+          {/* Action buttons */}
+          <div className="flex items-center gap-1 pt-0.5">
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-6 text-[11px] px-2"
+              onClick={() => setShowReply(!showReply)}
+            >
+              <Reply className="mr-1 h-3 w-3" />
+              {showReply ? 'Hide' : 'Reply'}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 text-[11px] px-2"
+              onClick={() => onStatusChange(signal.id, 'dismissed')}
+            >
+              <X className="mr-1 h-3 w-3" />
+              Dismiss
+            </Button>
+            <a
+              href={`https://reddit.com${signal.permalink}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ml-auto"
+            >
+              <Button variant="ghost" size="sm" className="h-6 text-[11px] px-2">
+                <ExternalLink className="h-3 w-3" />
+              </Button>
+            </a>
+          </div>
+
+          {/* Inline reply builder */}
+          {showReply && (
+            <ReplyBuilder
+              signalId={signal.id}
+              projectId={projectId}
+              permalink={signal.permalink}
+              onCopied={() => onStatusChange(signal.id, 'replied')}
+            />
+          )}
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+}

--- a/app/src/lib/ai/prompts.ts
+++ b/app/src/lib/ai/prompts.ts
@@ -430,3 +430,116 @@ ${context ? `Context: ${context}\n` : ''}
 Text to rewrite:
 ${text}`;
 }
+
+// ---- Outreach: Keyword Generation ----
+
+export const KEYWORD_GEN_SYSTEM_PROMPT = `You are an expert at identifying Reddit search keywords that surface conversations where a product could be naturally recommended. Focus on pain points, questions, and comparison threads — not branded terms.`;
+
+export function buildKeywordGenPrompt(
+  productName: string,
+  productDescription: string,
+  targetAudience: string | null
+): string {
+  return `## Product
+- **Name:** ${productName}
+- **Description:** ${productDescription}
+${targetAudience ? `- **Target Audience:** ${targetAudience}` : ''}
+
+## Task
+Generate 15-20 Reddit search keywords/phrases that would find posts where someone could naturally recommend "${productName}". Include:
+- Pain point phrases (e.g., "tired of manually", "looking for alternative to")
+- Question patterns (e.g., "best tool for", "how do you handle")
+- Comparison/alternative threads (e.g., "X vs Y", "alternative to Z")
+- Problem descriptions (e.g., "struggling with", "need help with")
+
+Format as JSON:
+{
+  "keywords": ["keyword1", "keyword2", ...]
+}`;
+}
+
+// ---- Outreach: Intent Classification ----
+
+export const INTENT_CLASSIFY_SYSTEM_PROMPT = `You are an expert at classifying Reddit posts by their commercial intent — specifically, how suitable they are for receiving a natural product recommendation in the comments.
+
+Intent types:
+- "question": User asking for recommendations or solutions
+- "comparison": User comparing products/tools
+- "problem": User describing a pain point your product solves
+- "discussion": General discussion tangentially related
+- "showcase": Someone showing their own project/tool
+
+Rate intent_score from 0.0 to 1.0 where 1.0 = perfect fit for a reply.`;
+
+export function buildIntentClassifyPrompt(
+  posts: { id: string; title: string; selftext: string; subreddit: string }[],
+  productName: string,
+  productDescription: string
+): string {
+  const postList = posts
+    .map(
+      (p, i) =>
+        `${i + 1}. [${p.id}] r/${p.subreddit}: "${p.title}"
+   ${p.selftext ? p.selftext.slice(0, 300) : '[no body]'}`
+    )
+    .join('\n\n');
+
+  return `## Product Context
+- **Product:** ${productName}
+- **Description:** ${productDescription}
+
+## Posts to Classify
+${postList}
+
+## Task
+Classify each post's intent type and score for "${productName}". Return JSON:
+{
+  "classifications": [
+    { "reddit_id": "abc123", "intent_type": "question", "intent_score": 0.85 }
+  ]
+}`;
+}
+
+// ---- Outreach: Reply Draft ----
+
+export const REPLY_DRAFT_SYSTEM_PROMPT = `You are an expert Reddit commenter who writes helpful, authentic replies that naturally mention a product when relevant. Your replies:
+- Lead with genuine value (answer the question, share insight)
+- Sound like a real Reddit user, not a marketer
+- Mention the product naturally in 1-2 sentences max
+- Never use marketing buzzwords or hard sells
+- Respect subreddit rules and culture
+- Include personal experience framing ("I've been using...", "What worked for me was...")`;
+
+export function buildReplyDraftPrompt(
+  post: { title: string; body: string | null; subreddit: string; author: string },
+  product: { name: string; description: string; url?: string },
+  complianceNotes: string | null,
+  replyMode: 'helpful' | 'experience' | 'subtle'
+): string {
+  const modeInstructions: Record<string, string> = {
+    helpful: 'Write a genuinely helpful reply that answers the question or addresses the problem, then naturally mention the product as one option.',
+    experience: 'Write as someone sharing their personal experience. Start with your situation, what you tried, and how the product helped.',
+    subtle: 'Write a valuable reply focused entirely on the topic. Mention the product in passing (one brief sentence) as something you happened to use.',
+  };
+
+  return `## Thread
+- **Subreddit:** r/${post.subreddit}
+- **Author:** u/${post.author}
+- **Title:** ${post.title}
+- **Body:** ${post.body || '[no body]'}
+
+## Product
+- **Name:** ${product.name}
+- **Description:** ${product.description}
+${product.url ? `- **URL:** ${product.url}` : ''}
+
+${complianceNotes ? `## Subreddit Rules\n${complianceNotes}\n` : ''}
+## Reply Mode
+${modeInstructions[replyMode]}
+
+## Task
+Write a Reddit reply (100-250 words). Format as JSON:
+{
+  "reply": "Your reply text here in Reddit markdown"
+}`;
+}

--- a/app/src/lib/outreach/compliance.ts
+++ b/app/src/lib/outreach/compliance.ts
@@ -1,0 +1,86 @@
+/**
+ * Subreddit rule parsing and safety scoring for outreach compliance.
+ */
+
+export interface ComplianceProfile {
+  selfPromoAllowed: boolean;
+  linkPostsAllowed: boolean;
+  minAccountAge: number | null;
+  minKarma: number | null;
+  flairRequired: boolean;
+  restrictedKeywords: string[];
+}
+
+export type SafetyLevel = 'safe' | 'caution' | 'strict';
+
+const PROMO_BLOCK_PATTERNS = [
+  /no\s*(self[- ]?)?promot/i,
+  /no\s*advertis/i,
+  /no\s*spam/i,
+  /no\s*market/i,
+  /no\s*affiliate/i,
+];
+
+const ACCOUNT_AGE_PATTERN = /(\d+)\s*(day|week|month)/i;
+const KARMA_PATTERN = /(\d+)\s*karma/i;
+
+export function parseComplianceProfile(
+  rulesJson: Record<string, unknown>[]
+): ComplianceProfile {
+  const allText = rulesJson
+    .map((r) => `${r.short_name || ''} ${r.description || ''}`)
+    .join(' ');
+
+  const selfPromoAllowed = !PROMO_BLOCK_PATTERNS.some((p) => p.test(allText));
+
+  const linkPostsAllowed = !/no\s*link\s*posts?/i.test(allText);
+
+  const ageMatch = allText.match(ACCOUNT_AGE_PATTERN);
+  let minAccountAge: number | null = null;
+  if (ageMatch) {
+    const num = parseInt(ageMatch[1], 10);
+    const unit = ageMatch[2].toLowerCase();
+    if (unit.startsWith('week')) minAccountAge = num * 7;
+    else if (unit.startsWith('month')) minAccountAge = num * 30;
+    else minAccountAge = num;
+  }
+
+  const karmaMatch = allText.match(KARMA_PATTERN);
+  const minKarma = karmaMatch ? parseInt(karmaMatch[1], 10) : null;
+
+  const flairRequired = /flair\s*(is\s*)?required/i.test(allText);
+
+  const restrictedKeywords: string[] = [];
+  if (/no\s*referral/i.test(allText)) restrictedKeywords.push('referral');
+  if (/no\s*coupon/i.test(allText)) restrictedKeywords.push('coupon');
+  if (/no\s*discount/i.test(allText)) restrictedKeywords.push('discount');
+
+  return {
+    selfPromoAllowed,
+    linkPostsAllowed,
+    minAccountAge,
+    minKarma,
+    flairRequired,
+    restrictedKeywords,
+  };
+}
+
+export function computeSafetyScore(profile: ComplianceProfile): number {
+  let score = 1.0;
+
+  if (!profile.selfPromoAllowed) score -= 0.4;
+  if (!profile.linkPostsAllowed) score -= 0.1;
+  if (profile.minAccountAge && profile.minAccountAge > 30) score -= 0.1;
+  if (profile.minKarma && profile.minKarma > 100) score -= 0.1;
+  if (profile.flairRequired) score -= 0.05;
+  if (profile.restrictedKeywords.length > 0) score -= 0.05 * profile.restrictedKeywords.length;
+
+  return Math.max(0, Math.min(1, score));
+}
+
+export function getSafetyLevel(safetyScore: number | null): SafetyLevel {
+  if (safetyScore === null) return 'caution';
+  if (safetyScore >= 0.7) return 'safe';
+  if (safetyScore >= 0.4) return 'caution';
+  return 'strict';
+}

--- a/app/src/lib/outreach/detector.ts
+++ b/app/src/lib/outreach/detector.ts
@@ -1,0 +1,141 @@
+/**
+ * Signal detector: searches Reddit, filters by keywords, classifies intent via LLM, upserts signals.
+ */
+
+import { searchSubredditPosts } from '@/lib/reddit/fetcher';
+import { getAnthropicClient, AI_MODEL, MAX_TOKENS } from '@/lib/ai/client';
+import { INTENT_CLASSIFY_SYSTEM_PROMPT, buildIntentClassifyPrompt } from '@/lib/ai/prompts';
+import { computeCombinedScore } from '@/lib/outreach/scoring';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { RedditPost } from '@/types';
+
+interface DetectOptions {
+  projectId: string;
+  keywords: string[];
+  competitors: string[];
+  subreddits: string[];
+  subredditLimit: number;
+  productName: string;
+  productDescription: string;
+}
+
+interface ClassifiedPost {
+  reddit_id: string;
+  intent_type: string;
+  intent_score: number;
+}
+
+async function classifyPosts(
+  posts: RedditPost[],
+  productName: string,
+  productDescription: string
+): Promise<ClassifiedPost[]> {
+  if (posts.length === 0) return [];
+
+  const client = getAnthropicClient();
+  const prompt = buildIntentClassifyPrompt(posts, productName, productDescription);
+
+  const message = await client.messages.create({
+    model: AI_MODEL,
+    max_tokens: MAX_TOKENS,
+    system: INTENT_CLASSIFY_SYSTEM_PROMPT,
+    messages: [{ role: 'user', content: prompt }],
+  });
+
+  const textContent = message.content.find((c) => c.type === 'text');
+  if (!textContent || textContent.type !== 'text') return [];
+
+  let responseText = textContent.text.trim();
+  if (responseText.startsWith('```')) {
+    responseText = responseText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+  }
+
+  try {
+    const parsed = JSON.parse(responseText) as { classifications: ClassifiedPost[] };
+    return parsed.classifications || [];
+  } catch {
+    return [];
+  }
+}
+
+function matchesKeywords(post: RedditPost, keywords: string[]): string[] {
+  const text = `${post.title} ${post.selftext}`.toLowerCase();
+  return keywords.filter((kw) => text.includes(kw.toLowerCase()));
+}
+
+function mentionsCompetitor(post: RedditPost, competitors: string[]): boolean {
+  const text = `${post.title} ${post.selftext}`.toLowerCase();
+  return competitors.some((comp) => text.includes(comp.toLowerCase()));
+}
+
+export async function detectSignals(
+  supabase: SupabaseClient,
+  options: DetectOptions
+): Promise<number> {
+  const { projectId, keywords, competitors, subreddits, subredditLimit, productName, productDescription } = options;
+
+  // 1. Search Reddit across subreddits for keyword matches
+  const allPosts: RedditPost[] = [];
+  const limitPerSub = Math.min(25, Math.ceil(subredditLimit / Math.max(1, subreddits.length)));
+
+  for (const sub of subreddits.slice(0, 10)) {
+    for (const keyword of keywords.slice(0, 5)) {
+      const result = await searchSubredditPosts(sub, keyword, limitPerSub);
+      if (result.posts) {
+        allPosts.push(...result.posts);
+      }
+    }
+  }
+
+  // Deduplicate by reddit_id
+  const uniquePosts = new Map<string, RedditPost>();
+  for (const post of allPosts) {
+    if (!uniquePosts.has(post.id)) {
+      uniquePosts.set(post.id, post);
+    }
+  }
+
+  const postsToClassify = Array.from(uniquePosts.values());
+  if (postsToClassify.length === 0) return 0;
+
+  // 2. Classify intent via LLM (batch up to 20 at a time)
+  const batch = postsToClassify.slice(0, 20);
+  const classifications = await classifyPosts(batch, productName, productDescription);
+  const classMap = new Map(classifications.map((c) => [c.reddit_id, c]));
+
+  // 3. Upsert signals
+  const signals = batch.map((post) => {
+    const classification = classMap.get(post.id);
+    const intentScore = classification?.intent_score ?? 0.3;
+    const matchedKws = matchesKeywords(post, keywords);
+    const compMentioned = mentionsCompetitor(post, competitors);
+
+    return {
+      project_id: projectId,
+      reddit_id: post.id,
+      subreddit: post.subreddit,
+      title: post.title,
+      body: post.selftext || null,
+      author: post.author,
+      score: post.score,
+      num_comments: post.num_comments,
+      permalink: post.permalink,
+      created_utc: post.created_utc,
+      intent_type: classification?.intent_type ?? 'unknown',
+      intent_score: intentScore,
+      combined_score: computeCombinedScore(intentScore, post.created_utc, post.score, post.num_comments),
+      matched_keywords: matchedKws,
+      competitor_mentioned: compMentioned,
+      status: 'new',
+      fetched_at: new Date().toISOString(),
+    };
+  });
+
+  if (signals.length > 0) {
+    await supabase
+      .from('outreach_signals')
+      .upsert(signals, { onConflict: 'project_id,reddit_id' });
+  }
+
+  return signals.length;
+}

--- a/app/src/lib/outreach/scoring.ts
+++ b/app/src/lib/outreach/scoring.ts
@@ -1,0 +1,31 @@
+/**
+ * Combined scoring for outreach signals.
+ * Formula: intent(0.5) + freshness(0.3) + engagement(0.2)
+ */
+
+const MAX_AGE_HOURS = 72; // Posts older than 72h get 0 freshness score
+
+export function computeFreshnessScore(createdUtc: number): number {
+  const ageHours = (Date.now() / 1000 - createdUtc) / 3600;
+  if (ageHours <= 0) return 1;
+  if (ageHours >= MAX_AGE_HOURS) return 0;
+  return 1 - ageHours / MAX_AGE_HOURS;
+}
+
+export function computeEngagementScore(score: number, numComments: number): number {
+  // Normalize: log scale to handle viral posts gracefully
+  const scoreNorm = Math.min(1, Math.log10(Math.max(1, score)) / 4); // 10k = 1.0
+  const commentsNorm = Math.min(1, Math.log10(Math.max(1, numComments)) / 3); // 1k = 1.0
+  return scoreNorm * 0.6 + commentsNorm * 0.4;
+}
+
+export function computeCombinedScore(
+  intentScore: number,
+  createdUtc: number,
+  redditScore: number,
+  numComments: number
+): number {
+  const freshness = computeFreshnessScore(createdUtc);
+  const engagement = computeEngagementScore(redditScore, numComments);
+  return intentScore * 0.5 + freshness * 0.3 + engagement * 0.2;
+}

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -258,3 +258,75 @@ export interface SpliceResponse {
 
 export type AiTone = 'Engaging' | 'Humorous' | 'Creative' | 'Sarcastic' | 'Inspirational' | 'Concise';
 export type RewriteOption = AiTone | 'Improve grammar' | 'Engaging hook' | 'More details';
+
+// ---- Outreach types ----
+
+export interface OutreachConfig {
+  id: string;
+  project_id: string;
+  reddit_username: string | null;
+  keywords: string[];
+  competitors: string[];
+  webhook_url: string | null;
+  webhook_type: string | null;
+  subreddit_limit: number;
+  polling_enabled: boolean;
+  setup_completed: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface OutreachSignal {
+  id: string;
+  project_id: string;
+  reddit_id: string;
+  subreddit: string;
+  title: string;
+  body: string | null;
+  author: string;
+  score: number;
+  num_comments: number;
+  permalink: string;
+  created_utc: number;
+  intent_type: string | null;
+  intent_score: number;
+  combined_score: number;
+  matched_keywords: string[];
+  competitor_mentioned: boolean;
+  status: 'new' | 'replied' | 'dismissed' | 'converted';
+  fetched_at: string;
+}
+
+export interface OutreachReply {
+  id: string;
+  project_id: string;
+  signal_id: string | null;
+  thread_permalink: string | null;
+  draft_text: string | null;
+  reply_mode: string | null;
+  reddit_comment_id: string | null;
+  posted_at: string | null;
+  current_score: number | null;
+  reply_count: number;
+  op_replied: boolean;
+  last_checked_at: string | null;
+  status: 'draft' | 'copied' | 'posted' | 'tracking';
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SubredditRule {
+  id: string;
+  subreddit: string;
+  rules_json: Record<string, unknown>[];
+  compliance_profile: {
+    selfPromoAllowed: boolean;
+    linkPostsAllowed: boolean;
+    minAccountAge: number | null;
+    minKarma: number | null;
+    flairRequired: boolean;
+    restrictedKeywords: string[];
+  };
+  safety_score: number | null;
+  analyzed_at: string;
+}

--- a/app/supabase/migrations/005_outreach.sql
+++ b/app/supabase/migrations/005_outreach.sql
@@ -1,0 +1,118 @@
+-- ============================================================
+-- 005_outreach.sql — Outreach feature tables + RLS
+-- ============================================================
+
+-- 1. outreach_configs: one per project
+create table if not exists outreach_configs (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references projects(id) on delete cascade,
+  reddit_username text,
+  keywords jsonb default '[]'::jsonb,
+  competitors jsonb default '[]'::jsonb,
+  webhook_url text,
+  webhook_type text,
+  subreddit_limit integer default 20,
+  polling_enabled boolean default true,
+  setup_completed boolean default false,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  constraint outreach_configs_project_id_key unique (project_id)
+);
+
+alter table outreach_configs enable row level security;
+
+create policy "Users can manage their own outreach configs"
+  on outreach_configs for all
+  using (project_id in (select id from projects where user_id = auth.uid()))
+  with check (project_id in (select id from projects where user_id = auth.uid()));
+
+-- 2. outreach_signals: detected leads
+create table if not exists outreach_signals (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references projects(id) on delete cascade,
+  reddit_id text not null,
+  subreddit text not null,
+  title text not null,
+  body text,
+  author text not null,
+  score integer default 0,
+  num_comments integer default 0,
+  permalink text not null,
+  created_utc bigint not null,
+  intent_type text,
+  intent_score real default 0,
+  combined_score real default 0,
+  matched_keywords text[] default '{}',
+  competitor_mentioned boolean default false,
+  status text default 'new',
+  fetched_at timestamptz default now(),
+  constraint outreach_signals_project_reddit unique (project_id, reddit_id)
+);
+
+alter table outreach_signals enable row level security;
+
+create policy "Users can manage their own outreach signals"
+  on outreach_signals for all
+  using (project_id in (select id from projects where user_id = auth.uid()))
+  with check (project_id in (select id from projects where user_id = auth.uid()));
+
+-- 3. outreach_replies: reply drafts + tracking
+create table if not exists outreach_replies (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references projects(id) on delete cascade,
+  signal_id uuid references outreach_signals(id) on delete set null,
+  thread_permalink text,
+  draft_text text,
+  reply_mode text,
+  reddit_comment_id text,
+  posted_at timestamptz,
+  current_score integer,
+  reply_count integer default 0,
+  op_replied boolean default false,
+  last_checked_at timestamptz,
+  status text default 'draft',
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+alter table outreach_replies enable row level security;
+
+create policy "Users can manage their own outreach replies"
+  on outreach_replies for all
+  using (project_id in (select id from projects where user_id = auth.uid()))
+  with check (project_id in (select id from projects where user_id = auth.uid()));
+
+-- 4. subreddit_rules: cached compliance profiles (shared, no RLS)
+create table if not exists subreddit_rules (
+  id uuid primary key default gen_random_uuid(),
+  subreddit text not null,
+  rules_json jsonb default '[]'::jsonb,
+  compliance_profile jsonb default '{}'::jsonb,
+  safety_score real,
+  analyzed_at timestamptz default now(),
+  constraint subreddit_rules_subreddit_key unique (subreddit)
+);
+
+-- No RLS for subreddit_rules — shared data accessed via service role
+
+-- Indexes
+create index if not exists idx_outreach_signals_project_status on outreach_signals(project_id, status);
+create index if not exists idx_outreach_signals_combined_score on outreach_signals(project_id, combined_score desc);
+create index if not exists idx_outreach_replies_project_status on outreach_replies(project_id, status);
+
+-- updated_at triggers
+create or replace function update_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger outreach_configs_updated_at
+  before update on outreach_configs
+  for each row execute function update_updated_at();
+
+create trigger outreach_replies_updated_at
+  before update on outreach_replies
+  for each row execute function update_updated_at();


### PR DESCRIPTION
## Summary
- Adds full Outreach feature skeleton: setup wizard, signals feed, reply tracker, and competitor watch pages
- 9 API routes wired to Supabase (signals detection, AI reply drafting, subreddit compliance, config management)
- DB migration with 4 tables (outreach_configs, outreach_signals, outreach_replies, subreddit_rules) and RLS policies
- Sidebar updated with collapsible Outreach section (Signals, Tracker, Competitors)
- Signal detection pipeline: Reddit search → AI intent classification → scored 3-column card grid with inline reply builder

## Test plan
- [ ] Navigate to Outreach in sidebar — should show setup prompt with "Start Setup" and "Skip for now"
- [ ] Complete setup wizard (keywords, competitors, reddit username) — config saves to DB
- [ ] Signals page loads and triggers Reddit search + AI classification
- [ ] Draft Reply inline builder generates AI reply and copies to clipboard
- [ ] Tracker page shows replies with stats cards and status filters
- [ ] Competitors page shows competitor mentions with summary cards and filtering
- [ ] Verify DB migration creates all 4 tables with correct RLS policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)