### PR TITLE
Add DM workflow manager for outreach

### DIFF
--- a/app/src/app/api/ai/dm-draft/route.ts
+++ b/app/src/app/api/ai/dm-draft/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAnthropicClient, AI_MODEL, MAX_TOKENS } from '@/lib/ai/client';
+import { DM_DRAFT_SYSTEM_PROMPT, buildDmDraftPrompt } from '@/lib/ai/prompts';
+import { getTemplate } from '@/lib/outreach/dm-templates';
+import { createClient, createServiceClient } from '@/lib/supabase/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { dm_id, project_id, template_id } = body;
+
+    if (!dm_id || !project_id) {
+      return NextResponse.json(
+        { error: 'dm_id and project_id are required' },
+        { status: 400 }
+      );
+    }
+
+    // Verify auth
+    const authClient = await createClient();
+    const { data: { user } } = await authClient.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const supabase = await createServiceClient();
+
+    // Get DM record
+    const { data: dm } = await supabase
+      .from('outreach_dms')
+      .select('*, signal:outreach_signals(title, subreddit, permalink)')
+      .eq('id', dm_id)
+      .single();
+
+    if (!dm) {
+      return NextResponse.json({ error: 'DM record not found' }, { status: 404 });
+    }
+
+    // Get project for product context
+    const { data: project } = await supabase
+      .from('projects')
+      .select('product_name, product_description, product_url')
+      .eq('id', project_id)
+      .single();
+
+    if (!project) {
+      return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+    }
+
+    // Get template hint if provided
+    const template = template_id ? getTemplate(template_id) : null;
+
+    const client = getAnthropicClient();
+    const prompt = buildDmDraftPrompt(
+      {
+        username: dm.reddit_username,
+        commentText: dm.comment_text || '',
+        threadPermalink: dm.source_thread_permalink,
+      },
+      {
+        name: project.product_name,
+        description: project.product_description,
+        url: project.product_url || undefined,
+      },
+      {
+        templateHint: template ? { subject_hint: template.subject_hint, body_hint: template.body_hint } : null,
+        touchNumber: dm.touch_number || 0,
+        threadTitle: dm.signal?.title,
+        subreddit: dm.signal?.subreddit,
+      }
+    );
+
+    const message = await client.messages.create({
+      model: AI_MODEL,
+      max_tokens: MAX_TOKENS,
+      system: DM_DRAFT_SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const textContent = message.content.find((c) => c.type === 'text');
+    if (!textContent || textContent.type !== 'text') {
+      return NextResponse.json({ error: 'No response from AI' }, { status: 500 });
+    }
+
+    let responseText = textContent.text.trim();
+    if (responseText.startsWith('```')) {
+      responseText = responseText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+    }
+
+    const parsed = JSON.parse(responseText) as { subject: string; body: string };
+
+    // Update DM record with draft
+    const { error: updateError } = await supabase
+      .from('outreach_dms')
+      .update({
+        dm_subject: parsed.subject,
+        dm_body: parsed.body,
+        dm_template_id: template_id || null,
+        pipeline_stage: 'draft_generated',
+      })
+      .eq('id', dm_id);
+
+    if (updateError) {
+      return NextResponse.json({
+        subject: parsed.subject,
+        body: parsed.body,
+        saved: false,
+      });
+    }
+
+    return NextResponse.json({
+      subject: parsed.subject,
+      body: parsed.body,
+      saved: true,
+    });
+  } catch (error) {
+    console.error('DM draft error:', error);
+    return NextResponse.json({ error: 'Failed to generate DM draft' }, { status: 500 });
+  }
+}

--- a/app/src/app/api/outreach/dms/route.ts
+++ b/app/src/app/api/outreach/dms/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServiceClient } from '@/lib/supabase/server';
+
+export async function GET(request: NextRequest) {
+  try {
+    const projectId = request.nextUrl.searchParams.get('project_id');
+    if (!projectId) {
+      return NextResponse.json({ error: 'project_id is required' }, { status: 400 });
+    }
+
+    const supabase = await createServiceClient();
+    const pipelineStage = request.nextUrl.searchParams.get('pipeline_stage');
+    const followUpDue = request.nextUrl.searchParams.get('follow_up_due');
+
+    let query = supabase
+      .from('outreach_dms')
+      .select('*, signal:outreach_signals(title, subreddit, permalink)')
+      .eq('project_id', projectId)
+      .order('created_at', { ascending: false });
+
+    if (pipelineStage && pipelineStage !== 'all') {
+      query = query.eq('pipeline_stage', pipelineStage);
+    }
+
+    if (followUpDue === 'true') {
+      query = query.lte('follow_up_due', new Date().toISOString()).not('follow_up_due', 'is', null);
+    }
+
+    const { data, error } = await query.limit(100);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ dms: data ?? [] });
+  } catch (error) {
+    console.error('DMs fetch error:', error);
+    return NextResponse.json({ error: 'Failed to fetch DMs' }, { status: 500 });
+  }
+}

--- a/app/src/app/api/outreach/dms/scan/route.ts
+++ b/app/src/app/api/outreach/dms/scan/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient, createServiceClient } from '@/lib/supabase/server';
+import { monitorTrackedThreads } from '@/lib/outreach/thread-monitor';
+import { clearCommentCache } from '@/lib/reddit/fetcher';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { project_id, force } = body;
+
+    if (!project_id) {
+      return NextResponse.json({ error: 'project_id is required' }, { status: 400 });
+    }
+
+    // Use auth client to verify the user owns this project
+    const authClient = await createClient();
+    const { data: { user } } = await authClient.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Use service client for the actual scan (avoids RLS issues with seeded data)
+    const supabase = await createServiceClient();
+
+    // Verify project belongs to user
+    const { data: project } = await supabase
+      .from('projects')
+      .select('id')
+      .eq('id', project_id)
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (!project) {
+      return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+    }
+
+    // Staleness check: skip if last DM was created < 15 min ago (unless forced)
+    if (!force) {
+      const { data: latestDm } = await supabase
+        .from('outreach_dms')
+        .select('created_at')
+        .eq('project_id', project_id)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      const staleThreshold = 15 * 60 * 1000;
+      const isStale = !latestDm ||
+        Date.now() - new Date(latestDm.created_at).getTime() > staleThreshold;
+
+      if (!isStale) {
+        return NextResponse.json({ message: 'Data is fresh, skipping scan', scanned: false });
+      }
+    }
+
+    // Clear comment cache when forced so we get fresh data from Reddit
+    if (force) {
+      clearCommentCache();
+    }
+
+    // Get outreach config for reddit username
+    const { data: config } = await supabase
+      .from('outreach_configs')
+      .select('reddit_username, setup_completed')
+      .eq('project_id', project_id)
+      .maybeSingle();
+
+    if (!config?.setup_completed) {
+      return NextResponse.json({ message: 'Outreach setup not completed', scanned: false });
+    }
+
+    if (!config?.reddit_username) {
+      return NextResponse.json({ message: 'Reddit username not configured. Set it in Outreach setup.', scanned: false });
+    }
+
+    // Run thread monitoring
+    const detected = await monitorTrackedThreads(supabase, {
+      projectId: project_id,
+      redditUsername: config.reddit_username,
+    });
+
+    if (detected.length === 0) {
+      return NextResponse.json({ message: 'No new commenters detected', scanned: true, count: 0 });
+    }
+
+    // Upsert detected commenters into outreach_dms
+    const rows = detected.map((d) => ({
+      project_id,
+      reddit_username: d.reddit_username,
+      comment_text: d.comment_text,
+      comment_permalink: d.comment_permalink,
+      source_thread_permalink: d.source_thread_permalink,
+      source_signal_id: d.source_signal_id,
+      permission_type: d.permission_type,
+      permission_score: d.permission_score,
+      matched_pattern: d.matched_pattern,
+      pipeline_stage: d.permission_type === 'explicit_dm_request' ? 'dm_ready' : 'detected',
+    }));
+
+    const { error } = await supabase
+      .from('outreach_dms')
+      .upsert(rows, { onConflict: 'project_id,reddit_username,source_thread_permalink' });
+
+    if (error) {
+      console.error('DM upsert error:', error);
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ scanned: true, count: detected.length });
+  } catch (error) {
+    console.error('DM scan error:', error);
+    return NextResponse.json({ error: 'Failed to scan threads' }, { status: 500 });
+  }
+}

--- a/app/src/app/api/outreach/dms/sent/route.ts
+++ b/app/src/app/api/outreach/dms/sent/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient, createServiceClient } from '@/lib/supabase/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { dm_id, dm_content, follow_up_days } = body;
+
+    if (!dm_id) {
+      return NextResponse.json({ error: 'dm_id is required' }, { status: 400 });
+    }
+
+    const authClient = await createClient();
+    const { data: { user } } = await authClient.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const supabase = await createServiceClient();
+
+    // Get current DM to increment touch number
+    const { data: current } = await supabase
+      .from('outreach_dms')
+      .select('touch_number')
+      .eq('id', dm_id)
+      .single();
+
+    const touchNumber = (current?.touch_number ?? 0) + 1;
+
+    const update: Record<string, unknown> = {
+      pipeline_stage: 'dm_sent',
+      dm_sent_at: new Date().toISOString(),
+      touch_number: touchNumber,
+    };
+
+    if (dm_content) update.dm_body = dm_content;
+
+    if (follow_up_days && follow_up_days > 0) {
+      const followUpDate = new Date();
+      followUpDate.setDate(followUpDate.getDate() + follow_up_days);
+      update.follow_up_due = followUpDate.toISOString();
+    }
+
+    const { error } = await supabase
+      .from('outreach_dms')
+      .update(update)
+      .eq('id', dm_id);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('DM sent update error:', error);
+    return NextResponse.json({ error: 'Failed to mark DM as sent' }, { status: 500 });
+  }
+}

--- a/app/src/app/api/outreach/dms/stage/route.ts
+++ b/app/src/app/api/outreach/dms/stage/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient, createServiceClient } from '@/lib/supabase/server';
+
+const VALID_STAGES = ['detected', 'dm_ready', 'draft_generated', 'dm_sent', 'responded', 'converted', 'closed'];
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { dm_id, pipeline_stage, notes, outcome } = body;
+
+    if (!dm_id || !pipeline_stage) {
+      return NextResponse.json({ error: 'dm_id and pipeline_stage are required' }, { status: 400 });
+    }
+
+    if (!VALID_STAGES.includes(pipeline_stage)) {
+      return NextResponse.json({ error: 'Invalid pipeline stage' }, { status: 400 });
+    }
+
+    const authClient = await createClient();
+    const { data: { user } } = await authClient.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const supabase = await createServiceClient();
+
+    const update: Record<string, unknown> = { pipeline_stage };
+    if (notes !== undefined) update.notes = notes;
+    if (outcome !== undefined) update.outcome = outcome;
+
+    const { error } = await supabase
+      .from('outreach_dms')
+      .update(update)
+      .eq('id', dm_id);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('DM stage update error:', error);
+    return NextResponse.json({ error: 'Failed to update DM stage' }, { status: 500 });
+  }
+}

--- a/app/src/app/api/outreach/dms/templates/route.ts
+++ b/app/src/app/api/outreach/dms/templates/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { DM_TEMPLATES } from '@/lib/outreach/dm-templates';
+
+export async function GET() {
+  return NextResponse.json({ templates: DM_TEMPLATES });
+}

--- a/app/src/app/projects/[id]/outreach/dms/page.tsx
+++ b/app/src/app/projects/[id]/outreach/dms/page.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2, Scan, AlertCircle } from 'lucide-react';
+import { useProject } from '@/contexts/project-context';
+import { PageTransition, StaggerList, StaggerItem } from '@/components/motion';
+import { Header } from '@/components/layout/header';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Skeleton } from '@/components/ui/skeleton';
+import { DmCard } from '@/components/outreach/DmCard';
+import { toast } from 'sonner';
+import type { OutreachDM, DmPipelineStage } from '@/types';
+
+type DmFilter = 'all' | 'dm_ready' | 'draft_generated' | 'dm_sent' | 'responded';
+
+export default function OutreachDmsPage() {
+  const { project } = useProject();
+  const [dms, setDms] = useState<OutreachDM[]>([]);
+  const [allDms, setAllDms] = useState<OutreachDM[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [scanning, setScanning] = useState(false);
+  const [filter, setFilter] = useState<DmFilter>('all');
+
+  const fetchDms = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ project_id: project.id });
+      if (filter !== 'all') params.set('pipeline_stage', filter);
+
+      const res = await fetch(`/api/outreach/dms?${params}`);
+      const json = await res.json();
+
+      if (json.error) {
+        toast.error(json.error);
+        setDms([]);
+      } else {
+        setDms(json.dms || []);
+      }
+    } catch {
+      toast.error('Failed to load DMs');
+      setDms([]);
+    }
+    setLoading(false);
+  }, [project.id, filter]);
+
+  // Fetch all DMs for stats
+  useEffect(() => {
+    async function fetchAll() {
+      try {
+        const res = await fetch(`/api/outreach/dms?project_id=${project.id}`);
+        const json = await res.json();
+        if (json.dms) setAllDms(json.dms);
+      } catch { /* stats will show 0 */ }
+    }
+    fetchAll();
+  }, [project.id]);
+
+  useEffect(() => {
+    fetchDms();
+  }, [fetchDms]);
+
+  // Auto-scan on mount if stale
+  useEffect(() => {
+    async function autoScan() {
+      try {
+        const res = await fetch('/api/outreach/dms/scan', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ project_id: project.id }),
+        });
+        const json = await res.json();
+        if (json.scanned && json.count > 0) {
+          toast.success(`Found ${json.count} new DM lead${json.count !== 1 ? 's' : ''}`);
+          fetchDms();
+          // Refresh stats
+          const allRes = await fetch(`/api/outreach/dms?project_id=${project.id}`);
+          const allJson = await allRes.json();
+          if (allJson.dms) setAllDms(allJson.dms);
+        }
+      } catch { /* silent failure for auto-scan */ }
+    }
+    autoScan();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [project.id]);
+
+  async function handleScan() {
+    setScanning(true);
+    try {
+      const res = await fetch('/api/outreach/dms/scan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project_id: project.id, force: true }),
+      });
+      const json = await res.json();
+
+      if (json.error) {
+        toast.error(json.error);
+      } else if (json.scanned) {
+        toast.success(`Found ${json.count} new DM lead${json.count !== 1 ? 's' : ''}`);
+        fetchDms();
+        // Refresh stats
+        const allRes = await fetch(`/api/outreach/dms?project_id=${project.id}`);
+        const allJson = await allRes.json();
+        if (allJson.dms) setAllDms(allJson.dms);
+      } else if (json.message) {
+        toast.info(json.message);
+      } else {
+        toast.info('Data is fresh — no scan needed');
+      }
+    } catch {
+      toast.error('Failed to scan threads');
+    }
+    setScanning(false);
+  }
+
+  async function handleStageChange(dmId: string, stage: string, outcome?: string) {
+    // Optimistic update
+    setDms((prev) =>
+      prev.map((d) => (d.id === dmId ? { ...d, pipeline_stage: stage as DmPipelineStage, outcome: outcome || d.outcome } : d))
+    );
+
+    try {
+      const res = await fetch('/api/outreach/dms/stage', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dm_id: dmId, pipeline_stage: stage, outcome }),
+      });
+      const json = await res.json();
+      if (json.error) {
+        toast.error(json.error);
+        fetchDms();
+      } else {
+        toast.success(`Updated to ${stage.replace('_', ' ')}`);
+      }
+    } catch {
+      toast.error('Failed to update stage');
+      fetchDms();
+    }
+  }
+
+  // Stats
+  const totalDetected = allDms.length;
+  const readyCount = allDms.filter((d) => d.pipeline_stage === 'dm_ready' || d.pipeline_stage === 'draft_generated').length;
+  const sentCount = allDms.filter((d) => d.pipeline_stage === 'dm_sent').length;
+  const convertedCount = allDms.filter((d) => d.pipeline_stage === 'converted').length;
+  const followUpsDue = allDms.filter(
+    (d) => d.follow_up_due && new Date(d.follow_up_due).getTime() <= Date.now()
+  ).length;
+
+  return (
+    <PageTransition>
+      <div className="flex h-full flex-col">
+        <Header title="DM Leads" />
+        <div className="flex-1 overflow-auto">
+          <div className="mx-auto max-w-6xl p-6 space-y-6">
+            {/* Stats row */}
+            <div className="grid grid-cols-4 gap-3">
+              <Card>
+                <CardContent className="p-4 text-center">
+                  <p className="text-2xl font-bold">{totalDetected}</p>
+                  <p className="text-xs text-muted-foreground">Total Detected</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-4 text-center">
+                  <p className="text-2xl font-bold">{readyCount}</p>
+                  <p className="text-xs text-muted-foreground">Ready for DM</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-4 text-center">
+                  <p className="text-2xl font-bold">{sentCount}</p>
+                  <p className="text-xs text-muted-foreground">Sent</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-4 text-center">
+                  <p className="text-2xl font-bold">{convertedCount}</p>
+                  <p className="text-xs text-muted-foreground">Converted</p>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Follow-up banner */}
+            {followUpsDue > 0 && (
+              <div className="flex items-center gap-2 rounded-lg border border-orange-200 bg-orange-50 dark:border-orange-800 dark:bg-orange-950 p-3">
+                <AlertCircle className="h-4 w-4 text-orange-600" />
+                <span className="text-sm font-medium text-orange-700 dark:text-orange-300">
+                  {followUpsDue} follow-up{followUpsDue !== 1 ? 's' : ''} due
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="ml-auto h-7 text-xs"
+                  onClick={() => setFilter('dm_sent')}
+                >
+                  View sent DMs
+                </Button>
+              </div>
+            )}
+
+            {/* Filter + scan */}
+            <div className="flex items-center gap-2 flex-wrap">
+              <Tabs value={filter} onValueChange={(v) => setFilter(v as DmFilter)}>
+                <TabsList className="h-8">
+                  <TabsTrigger value="all" className="text-xs px-3 h-6">All</TabsTrigger>
+                  <TabsTrigger value="dm_ready" className="text-xs px-3 h-6">Ready</TabsTrigger>
+                  <TabsTrigger value="draft_generated" className="text-xs px-3 h-6">Drafted</TabsTrigger>
+                  <TabsTrigger value="dm_sent" className="text-xs px-3 h-6">Sent</TabsTrigger>
+                  <TabsTrigger value="responded" className="text-xs px-3 h-6">Responded</TabsTrigger>
+                </TabsList>
+              </Tabs>
+
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-8 text-xs ml-auto"
+                onClick={handleScan}
+                disabled={scanning}
+              >
+                {scanning ? (
+                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                ) : (
+                  <Scan className="mr-1 h-3 w-3" />
+                )}
+                {scanning ? 'Scanning...' : 'Scan Threads'}
+              </Button>
+            </div>
+
+            {/* DM cards — 3-column grid */}
+            {loading ? (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <Skeleton key={i} className="h-56 rounded-xl" />
+                ))}
+              </div>
+            ) : dms.length === 0 ? (
+              <div className="py-12 text-center text-muted-foreground">
+                No DM leads yet. Post replies to signals and we&apos;ll monitor the threads for interested commenters.
+              </div>
+            ) : (
+              <StaggerList className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                {dms.map((dm) => (
+                  <StaggerItem key={dm.id}>
+                    <DmCard
+                      dm={dm}
+                      projectId={project.id}
+                      onStageChange={handleStageChange}
+                    />
+                  </StaggerItem>
+                ))}
+              </StaggerList>
+            )}
+          </div>
+        </div>
+      </div>
+    </PageTransition>
+  );
+}

--- a/app/src/components/layout/project-sidebar.tsx
+++ b/app/src/components/layout/project-sidebar.tsx
@@ -23,6 +23,7 @@ import {
   Settings,
   Github,
   Bot,
+  Mail,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { createClient } from '@/lib/supabase/client';
@@ -55,6 +56,7 @@ export function ProjectSidebar({ project }: { project: Project }) {
     { href: `${base}/outreach/signals`, label: 'Signals', icon: Radio },
     { href: `${base}/outreach/tracker`, label: 'Tracker', icon: BarChart3 },
     { href: `${base}/outreach/competitors`, label: 'Competitors', icon: Users },
+    { href: `${base}/outreach/dms`, label: 'DMs', icon: Mail },
   ];
 
   const contextChildren = [

--- a/app/src/components/outreach/DmCard.tsx
+++ b/app/src/components/outreach/DmCard.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import { useState } from 'react';
+import { MessageSquare, Clock, Mail, ExternalLink, ChevronDown, ChevronUp, AlertCircle } from 'lucide-react';
+import { motion } from 'motion/react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import { cardHover, cardTap } from '@/lib/motion';
+import { DmPipelineBadge } from '@/components/outreach/DmPipelineBadge';
+import { DmDraftBuilder } from '@/components/outreach/DmDraftBuilder';
+import type { OutreachDM, PermissionType } from '@/types';
+
+interface DmCardProps {
+  dm: OutreachDM;
+  projectId: string;
+  onStageChange: (dmId: string, stage: string, outcome?: string) => void;
+}
+
+const permissionConfig: Record<PermissionType, { label: string; className: string }> = {
+  explicit_dm_request: {
+    label: 'DM requested',
+    className: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300',
+  },
+  positive_reply: {
+    label: 'Positive reply',
+    className: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300',
+  },
+  passive_commenter: {
+    label: 'Commenter',
+    className: 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-300',
+  },
+};
+
+function timeAgo(dateStr: string | null) {
+  if (!dateStr) return '';
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (seconds < 60) return 'just now';
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`;
+  return new Date(dateStr).toLocaleDateString();
+}
+
+function isFollowUpDue(dateStr: string | null): boolean {
+  if (!dateStr) return false;
+  return new Date(dateStr).getTime() <= Date.now();
+}
+
+export function DmCard({ dm, projectId, onStageChange }: DmCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const permission = permissionConfig[dm.permission_type] || permissionConfig.passive_commenter;
+  const subreddit = dm.signal?.subreddit || '';
+  const threadTitle = dm.signal?.title || 'Thread';
+  const followUpOverdue = isFollowUpDue(dm.follow_up_due);
+
+  return (
+    <motion.div whileHover={cardHover} whileTap={cardTap} className="h-full">
+      <Card className="transition-shadow hover:shadow-md h-full flex flex-col">
+        <CardContent className="p-4 flex flex-col flex-1 space-y-2.5">
+          {/* Top row: pipeline badge + permission type + subreddit */}
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <DmPipelineBadge stage={dm.pipeline_stage} />
+            <Badge
+              variant="secondary"
+              className={`text-[10px] px-1.5 py-0 ${permission.className}`}
+            >
+              {permission.label}
+            </Badge>
+            {subreddit && (
+              <span className="text-[11px] text-muted-foreground">r/{subreddit}</span>
+            )}
+            {followUpOverdue && (
+              <Badge
+                variant="secondary"
+                className="text-[10px] px-1.5 py-0 bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300 ml-auto"
+              >
+                <AlertCircle className="mr-0.5 h-2.5 w-2.5" />
+                Follow-up due
+              </Badge>
+            )}
+          </div>
+
+          {/* Username + thread context */}
+          <div className="space-y-1">
+            <div className="flex items-center gap-1">
+              <span className="font-medium text-sm">u/{dm.reddit_username}</span>
+              {dm.touch_number > 0 && (
+                <span className="text-[10px] text-muted-foreground">
+                  ({dm.touch_number} touch{dm.touch_number !== 1 ? 'es' : ''})
+                </span>
+              )}
+            </div>
+            {dm.signal && (
+              <a
+                href={`https://reddit.com${dm.signal.permalink}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-muted-foreground hover:underline line-clamp-1"
+              >
+                {threadTitle}
+              </a>
+            )}
+          </div>
+
+          {/* Comment preview */}
+          {dm.comment_text && (
+            <p className="text-xs text-muted-foreground line-clamp-2 italic">
+              &ldquo;{dm.comment_text}&rdquo;
+            </p>
+          )}
+
+          {/* Matched pattern indicator */}
+          {dm.matched_pattern && (
+            <span className="inline-flex rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium w-fit">
+              matched: &ldquo;{dm.matched_pattern}&rdquo;
+            </span>
+          )}
+
+          {/* Spacer */}
+          <div className="flex-1" />
+
+          {/* Meta row */}
+          <div className="flex items-center gap-2 text-[11px] text-muted-foreground flex-wrap">
+            {dm.dm_sent_at && (
+              <span className="flex items-center gap-0.5">
+                <Mail className="h-3 w-3" />
+                Sent {timeAgo(dm.dm_sent_at)}
+              </span>
+            )}
+            <span className="flex items-center gap-0.5">
+              <Clock className="h-3 w-3" />
+              {timeAgo(dm.created_at)}
+            </span>
+            <span className="ml-auto font-mono text-[10px]">
+              {dm.permission_score.toFixed(2)}
+            </span>
+          </div>
+
+          {/* Action buttons */}
+          <div className="flex items-center gap-1 pt-0.5 flex-wrap">
+            {/* Generate/Expand DM Builder */}
+            {dm.pipeline_stage !== 'dm_sent' && dm.pipeline_stage !== 'responded' && dm.pipeline_stage !== 'converted' && dm.pipeline_stage !== 'closed' && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-6 text-[11px] px-2"
+                onClick={() => setExpanded(!expanded)}
+              >
+                <MessageSquare className="mr-1 h-3 w-3" />
+                {expanded ? 'Hide' : 'DM'}
+                {expanded ? <ChevronUp className="ml-0.5 h-3 w-3" /> : <ChevronDown className="ml-0.5 h-3 w-3" />}
+              </Button>
+            )}
+
+            {/* Quick actions based on pipeline stage */}
+            {dm.pipeline_stage === 'dm_sent' && (
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-6 text-[11px] px-2 text-green-600"
+                  onClick={() => onStageChange(dm.id, 'responded', 'replied')}
+                >
+                  Got a reply
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 text-[11px] px-2"
+                  onClick={() => onStageChange(dm.id, 'closed', 'no_response')}
+                >
+                  No response
+                </Button>
+              </>
+            )}
+
+            {dm.pipeline_stage === 'responded' && (
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-6 text-[11px] px-2 text-amber-600"
+                  onClick={() => onStageChange(dm.id, 'converted')}
+                >
+                  Converted
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 text-[11px] px-2"
+                  onClick={() => onStageChange(dm.id, 'closed', 'moved_off_reddit')}
+                >
+                  Moved off-Reddit
+                </Button>
+              </>
+            )}
+
+            <a
+              href={`https://www.reddit.com/user/${dm.reddit_username}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ml-auto"
+            >
+              <Button variant="ghost" size="sm" className="h-6 text-[11px] px-2">
+                <ExternalLink className="h-3 w-3" />
+              </Button>
+            </a>
+          </div>
+
+          {/* Inline DM Draft Builder */}
+          {expanded && (
+            <DmDraftBuilder
+              dmId={dm.id}
+              projectId={projectId}
+              username={dm.reddit_username}
+              onSent={() => onStageChange(dm.id, 'dm_sent')}
+            />
+          )}
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+}

--- a/app/src/components/outreach/DmDraftBuilder.tsx
+++ b/app/src/components/outreach/DmDraftBuilder.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Loader2, Copy, ExternalLink, Sparkles, Check, X } from 'lucide-react';
+import { motion } from 'motion/react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { scaleFadeVariants } from '@/lib/motion';
+import { toast } from 'sonner';
+import type { DmTemplate } from '@/types';
+
+interface DmDraftBuilderProps {
+  dmId: string;
+  projectId: string;
+  username: string;
+  onSent?: (followUpDays: number | null) => void;
+}
+
+export function DmDraftBuilder({ dmId, projectId, username, onSent }: DmDraftBuilderProps) {
+  const [templateId, setTemplateId] = useState<string>('none');
+  const [templates, setTemplates] = useState<DmTemplate[]>([]);
+  const [subject, setSubject] = useState('');
+  const [body, setBody] = useState('');
+  const [generating, setGenerating] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [followUpDays, setFollowUpDays] = useState<string>('3');
+
+  // Fetch templates
+  useEffect(() => {
+    fetch('/api/outreach/dms/templates')
+      .then((res) => res.json())
+      .then((json) => {
+        if (json.templates) setTemplates(json.templates);
+      })
+      .catch(() => {});
+  }, []);
+
+  // Tab-return confirmation via visibilitychange
+  const handleVisibilityChange = useCallback(() => {
+    if (document.visibilityState === 'visible' && showConfirm === false && body) {
+      setShowConfirm(true);
+    }
+  }, [showConfirm, body]);
+
+  useEffect(() => {
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [handleVisibilityChange]);
+
+  async function handleGenerate() {
+    setGenerating(true);
+    try {
+      const res = await fetch('/api/ai/dm-draft', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          dm_id: dmId,
+          project_id: projectId,
+          template_id: templateId !== 'none' ? templateId : undefined,
+        }),
+      });
+
+      const json = await res.json();
+      if (json.error) {
+        toast.error(json.error);
+      } else {
+        setSubject(json.subject || '');
+        setBody(json.body || '');
+        toast.success('DM draft generated');
+      }
+    } catch {
+      toast.error('Failed to generate DM draft');
+    }
+    setGenerating(false);
+  }
+
+  async function handleCopyAndOpen() {
+    try {
+      await navigator.clipboard.writeText(body);
+      toast.success('DM body copied to clipboard');
+
+      // Open Reddit compose URL with pre-filled fields
+      const composeUrl = `https://www.reddit.com/message/compose/?to=${encodeURIComponent(username)}&subject=${encodeURIComponent(subject)}&message=${encodeURIComponent(body)}`;
+      window.open(composeUrl, '_blank');
+    } catch {
+      toast.error('Failed to copy to clipboard');
+    }
+  }
+
+  async function handleConfirmSent() {
+    const days = followUpDays === 'none' ? null : parseInt(followUpDays);
+
+    try {
+      await fetch('/api/outreach/dms/sent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          dm_id: dmId,
+          dm_content: body,
+          follow_up_days: days,
+        }),
+      });
+      toast.success('DM marked as sent');
+      onSent?.(days);
+    } catch {
+      toast.error('Failed to update DM status');
+    }
+    setShowConfirm(false);
+  }
+
+  return (
+    <motion.div
+      variants={scaleFadeVariants}
+      initial="hidden"
+      animate="visible"
+      exit="exit"
+      className="mt-3 space-y-3 rounded-lg border bg-muted/30 p-3"
+    >
+      {/* Template selector + Generate button */}
+      <div className="flex items-center gap-2">
+        <Select value={templateId} onValueChange={setTemplateId}>
+          <SelectTrigger className="h-8 w-44 text-xs">
+            <SelectValue placeholder="Template..." />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">No template</SelectItem>
+            {templates.map((t) => (
+              <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 text-xs"
+          onClick={handleGenerate}
+          disabled={generating}
+        >
+          {generating ? (
+            <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+          ) : (
+            <Sparkles className="mr-1 h-3 w-3" />
+          )}
+          {generating ? 'Generating...' : 'Generate DM'}
+        </Button>
+      </div>
+
+      {/* Subject field */}
+      <Input
+        value={subject}
+        onChange={(e) => setSubject(e.target.value)}
+        placeholder="Subject line..."
+        className="text-sm h-8"
+      />
+
+      {/* Body field */}
+      <Textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="DM body will appear here. You can edit before sending."
+        className="min-h-[100px] text-sm"
+      />
+
+      {/* Actions */}
+      {(subject || body) && !showConfirm && (
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            className="h-8 text-xs"
+            onClick={handleCopyAndOpen}
+          >
+            <Copy className="mr-1 h-3 w-3" />
+            Copy & Open DM
+          </Button>
+          <a
+            href={`https://www.reddit.com/user/${username}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Button variant="ghost" size="sm" className="h-8 text-xs">
+              <ExternalLink className="mr-1 h-3 w-3" />
+              u/{username}
+            </Button>
+          </a>
+        </div>
+      )}
+
+      {/* Tab-return confirmation */}
+      {showConfirm && (
+        <motion.div
+          initial={{ opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950 p-2"
+        >
+          <span className="text-xs font-medium text-blue-700 dark:text-blue-300">
+            Did you send the DM?
+          </span>
+          <div className="ml-auto flex items-center gap-1">
+            <Select value={followUpDays} onValueChange={setFollowUpDays}>
+              <SelectTrigger className="h-6 w-24 text-[10px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="1">1 day</SelectItem>
+                <SelectItem value="3">3 days</SelectItem>
+                <SelectItem value="7">7 days</SelectItem>
+                <SelectItem value="none">No follow-up</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button
+              size="sm"
+              className="h-6 text-[10px] px-2"
+              onClick={handleConfirmSent}
+            >
+              <Check className="mr-1 h-3 w-3" />
+              Yes, sent
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 text-[10px] px-2"
+              onClick={() => setShowConfirm(false)}
+            >
+              <X className="mr-1 h-3 w-3" />
+              Not yet
+            </Button>
+          </div>
+        </motion.div>
+      )}
+    </motion.div>
+  );
+}

--- a/app/src/components/outreach/DmPipelineBadge.tsx
+++ b/app/src/components/outreach/DmPipelineBadge.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import type { DmPipelineStage } from '@/types';
+
+const config: Record<DmPipelineStage, { label: string; color: string; dot: string }> = {
+  detected: { label: 'Detected', color: 'text-gray-600', dot: 'bg-gray-500' },
+  dm_ready: { label: 'Ready', color: 'text-blue-600', dot: 'bg-blue-500' },
+  draft_generated: { label: 'Drafted', color: 'text-purple-600', dot: 'bg-purple-500' },
+  dm_sent: { label: 'Sent', color: 'text-green-600', dot: 'bg-green-500' },
+  responded: { label: 'Responded', color: 'text-emerald-600', dot: 'bg-emerald-500' },
+  converted: { label: 'Converted', color: 'text-amber-600', dot: 'bg-amber-500' },
+  closed: { label: 'Closed', color: 'text-slate-600', dot: 'bg-slate-500' },
+};
+
+interface DmPipelineBadgeProps {
+  stage: DmPipelineStage;
+  className?: string;
+}
+
+export function DmPipelineBadge({ stage, className }: DmPipelineBadgeProps) {
+  const { label, color, dot } = config[stage] || config.detected;
+
+  return (
+    <span className={cn('inline-flex items-center gap-1 text-[10px] font-medium', color, className)}>
+      <span className={cn('h-1.5 w-1.5 rounded-full', dot)} />
+      {label}
+    </span>
+  );
+}

--- a/app/src/lib/ai/prompts.ts
+++ b/app/src/lib/ai/prompts.ts
@@ -634,3 +634,55 @@ Write a Reddit reply (100-250 words). Format as JSON:
   "reply": "Your reply text here in Reddit markdown"
 }`;
 }
+
+// ---- DM Draft ----
+
+export const DM_DRAFT_SYSTEM_PROMPT = `You are an expert at writing Reddit DMs that feel personal and get responses. Your DMs:
+- Reference the specific comment/thread where you connected (builds trust)
+- Sound like a real person continuing a conversation, NOT a sales pitch
+- Are concise — DMs that are too long don't get read
+- Include a clear subject line that piques curiosity without being clickbait
+- Adapt tone based on the conversation context (casual if they were casual, professional if they were professional)
+- Never use marketing buzzwords, hard sells, or generic greetings
+- Include one specific call-to-action (share a link, answer a question, suggest a call)
+- For follow-ups, acknowledge the time gap and make it easy to say "not interested"`;
+
+export function buildDmDraftPrompt(
+  commenter: { username: string; commentText: string; threadPermalink: string },
+  product: { name: string; description: string; url?: string },
+  options: {
+    templateHint?: { subject_hint: string; body_hint: string } | null;
+    touchNumber?: number;
+    threadTitle?: string;
+    subreddit?: string;
+  }
+): string {
+  const isFollowUp = (options.touchNumber ?? 0) > 0;
+
+  return `## Context
+- **Commenter:** u/${commenter.username}
+- **Their comment:** "${commenter.commentText}"
+- **Thread:** ${options.threadTitle || commenter.threadPermalink}
+${options.subreddit ? `- **Subreddit:** r/${options.subreddit}` : ''}
+${isFollowUp ? `- **Touch number:** ${options.touchNumber} (this is a follow-up DM)` : '- **Touch number:** 0 (first DM to this person)'}
+
+## Product
+- **Name:** ${product.name}
+- **Description:** ${product.description}
+${product.url ? `- **URL:** ${product.url}` : ''}
+
+${options.templateHint ? `## Template Structure
+Use this as a structural guide (adapt the language to fit the conversation):
+- **Subject pattern:** ${options.templateHint.subject_hint}
+- **Body pattern:** ${options.templateHint.body_hint}
+` : ''}
+## Task
+Write a Reddit DM (subject + body) to u/${commenter.username}.${isFollowUp ? ' This is a follow-up — acknowledge the previous message and keep it brief.' : ' Reference their comment to show this is personal, not spam.'}
+
+Keep the body under 150 words. Format as JSON:
+{
+  "subject": "Your subject line here",
+  "body": "Your DM body here"
+}`;
+}
+

--- a/app/src/lib/outreach/dm-templates.ts
+++ b/app/src/lib/outreach/dm-templates.ts
@@ -1,0 +1,43 @@
+import type { DmTemplate } from '@/types';
+
+export const DM_TEMPLATES: DmTemplate[] = [
+  {
+    id: 'resource-delivery',
+    name: 'Resource Delivery',
+    description: "Share a resource they asked about — checklist, guide, link, etc.",
+    subject_hint: "Here's the [resource] you asked about",
+    body_hint: "Hey! Saw your comment about [topic]. Here's [specific resource]. [Brief value prop]. Let me know if you have any questions!",
+  },
+  {
+    id: 'follow-up',
+    name: 'Follow-up',
+    description: 'Continue a conversation that started in the thread.',
+    subject_hint: 'Following up on our chat in r/[subreddit]',
+    body_hint: "Hey, we were chatting in [thread]. Wanted to share the full version / more details. [Expand on the thread conversation]. Hope this helps!",
+  },
+  {
+    id: 'qualification',
+    name: 'Qualification',
+    description: 'Ask a qualifying question to gauge fit before pitching.',
+    subject_hint: 'Quick question about [their situation]',
+    body_hint: "Hey! Saw your comment about [problem]. Quick q — [qualifying question about timeline/budget/stack/team size]? I might have something that could help depending on your answer.",
+  },
+  {
+    id: 'meeting-bridge',
+    name: 'Meeting Bridge',
+    description: 'Offer a quick call to walk through something complex.',
+    subject_hint: 'Easier to walk through this live — 10 min?',
+    body_hint: "Hey! Your question about [topic] has a few moving parts. Easier to walk through live than type it all out. Would a quick 10-min call work? I can show you [specific thing]. No pressure either way!",
+  },
+  {
+    id: 'close-loop',
+    name: 'Close Loop',
+    description: 'Follow up on a previous DM that got no response.',
+    subject_hint: 'Still relevant, or should I close this out?',
+    body_hint: "Hey! I reached out [X days] ago about [topic]. Totally understand if the timing isn't right — just wanted to check if this is still relevant or if I should close this out. Either way, no worries!",
+  },
+];
+
+export function getTemplate(id: string): DmTemplate | undefined {
+  return DM_TEMPLATES.find((t) => t.id === id);
+}

--- a/app/src/lib/outreach/permission-detector.ts
+++ b/app/src/lib/outreach/permission-detector.ts
@@ -1,0 +1,83 @@
+import type { PermissionType } from '@/types';
+
+export interface PermissionResult {
+  type: PermissionType;
+  score: number;
+  matchedPattern: string | null;
+}
+
+// Tier 1: Explicit DM request patterns (score 0.95)
+const EXPLICIT_DM_PATTERNS = [
+  /\bdm\s+me\b/i,
+  /\bpm\s+me\b/i,
+  /\bsend\s+me\s+(a\s+)?(dm|pm|message)\b/i,
+  /\bmessage\s+me\b/i,
+  /\bcan\s+you\s+(dm|pm|message)\s+me\b/i,
+  /\bshoot\s+me\s+a\s+(dm|pm|message)\b/i,
+  /\bdrop\s+me\s+a\s+(dm|pm|message|line)\b/i,
+  /\bhit\s+me\s+up\b/i,
+  /\b(i('d|\s+would)\s+love|please)\s+(a\s+)?(dm|pm|message)\b/i,
+  /\bslide\s+into\s+(my\s+)?(dm|pm)s?\b/i,
+  /\bsend\s+(it|that|the\s+link|the\s+info)\s+(to\s+)?me\b/i,
+  /\bcan\s+(i|you)\s+get\s+(that|it|a\s+link)\s+(via\s+)?(dm|pm|message)?\b/i,
+  /\bi('ll|will)\s+(dm|pm|message)\s+you\b/i,
+  /\bcheck\s+(your|my)\s+(dm|pm|inbox)\b/i,
+];
+
+// Tier 2: Positive reply patterns (score 0.75, requires isReplyToUser)
+const POSITIVE_REPLY_PATTERNS = [
+  /\bsounds?\s+(great|amazing|awesome|good|interesting|perfect)\b/i,
+  /\b(very\s+)?interested\b/i,
+  /\bwhere\s+can\s+i\s+(find|get|try|sign\s+up|download)\b/i,
+  /\bhow\s+(do|can)\s+(i|we)\s+(get|try|use|access|sign\s+up)\b/i,
+  /\bdo\s+you\s+have\s+a\s+(link|url|website)\b/i,
+  /\bwhat('s|\s+is)\s+(the|your)\s+(link|url|website|pricing)\b/i,
+  /\bi('d|\s+would)\s+love\s+to\s+(try|check|see|learn)\b/i,
+  /\bthat('s|\s+is)\s+(exactly|just)\s+what\s+i\s+(need|was\s+looking\s+for)\b/i,
+  /\bcan\s+(i|you)\s+share\s+(more|the\s+link|details)\b/i,
+  /\btell\s+me\s+more\b/i,
+  /\bthis\s+is\s+(awesome|great|amazing|perfect|exactly\s+what)\b/i,
+  /\byes\s+please\b/i,
+  /\bcount\s+me\s+in\b/i,
+  /\bsign\s+me\s+up\b/i,
+  /\bi('m|\s+am)\s+(in|down|interested)\b/i,
+  /\btake\s+my\s+money\b/i,
+];
+
+export function detectPermission(
+  commentText: string,
+  isReplyToUser: boolean
+): PermissionResult {
+  // Tier 1: Check for explicit DM request
+  for (const pattern of EXPLICIT_DM_PATTERNS) {
+    const match = commentText.match(pattern);
+    if (match) {
+      return {
+        type: 'explicit_dm_request',
+        score: 0.95,
+        matchedPattern: match[0],
+      };
+    }
+  }
+
+  // Tier 2: Check for positive reply (only if it's a direct reply to the user)
+  if (isReplyToUser) {
+    for (const pattern of POSITIVE_REPLY_PATTERNS) {
+      const match = commentText.match(pattern);
+      if (match) {
+        return {
+          type: 'positive_reply',
+          score: 0.75,
+          matchedPattern: match[0],
+        };
+      }
+    }
+  }
+
+  // Tier 3: Passive commenter (fallback)
+  return {
+    type: 'passive_commenter',
+    score: 0.3,
+    matchedPattern: null,
+  };
+}

--- a/app/src/lib/outreach/thread-monitor.ts
+++ b/app/src/lib/outreach/thread-monitor.ts
@@ -1,0 +1,97 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { PermissionType } from '@/types';
+import { fetchThreadComments } from '@/lib/reddit/fetcher';
+import { detectPermission } from '@/lib/outreach/permission-detector';
+
+export interface DetectedCommenter {
+  reddit_username: string;
+  comment_text: string;
+  comment_permalink: string;
+  source_thread_permalink: string;
+  source_signal_id: string | null;
+  permission_type: PermissionType;
+  permission_score: number;
+  matched_pattern: string | null;
+}
+
+export async function monitorTrackedThreads(
+  supabase: SupabaseClient,
+  { projectId, redditUsername }: { projectId: string; redditUsername: string }
+): Promise<DetectedCommenter[]> {
+  // 1. Get tracked threads (replies that have been copied/posted/tracking)
+  const { data: replies } = await supabase
+    .from('outreach_replies')
+    .select('thread_permalink, signal_id, reddit_comment_id')
+    .eq('project_id', projectId)
+    .in('status', ['copied', 'posted', 'tracking'])
+    .order('created_at', { ascending: false })
+    .limit(10);
+
+  if (!replies || replies.length === 0) return [];
+
+  // 2. Get already-tracked usernames for this project to avoid duplicates
+  const { data: existingDms } = await supabase
+    .from('outreach_dms')
+    .select('reddit_username, source_thread_permalink')
+    .eq('project_id', projectId);
+
+  const existingKeys = new Set(
+    (existingDms || []).map((d) => `${d.reddit_username}::${d.source_thread_permalink}`)
+  );
+
+  const detected: DetectedCommenter[] = [];
+
+  // 3. For each tracked thread, fetch comments and detect new leads
+  for (const reply of replies) {
+    if (!reply.thread_permalink) continue;
+
+    const comments = await fetchThreadComments(reply.thread_permalink);
+    if (comments.length === 0) continue;
+
+    // Build a set of the user's own comment IDs for reply detection
+    const userCommentIds = new Set<string>();
+    if (reply.reddit_comment_id) {
+      userCommentIds.add(`t1_${reply.reddit_comment_id}`);
+    }
+    // Also detect by username
+    const lowerUsername = redditUsername.toLowerCase();
+
+    for (const comment of comments) {
+      // Skip the user's own comments
+      if (comment.author.toLowerCase() === lowerUsername) {
+        // Track user's comment IDs for isReplyToUser detection
+        userCommentIds.add(comment.id);
+        continue;
+      }
+
+      // Skip deleted/removed authors
+      if (comment.author === '[deleted]' || comment.author === 'AutoModerator') continue;
+
+      // Skip already-tracked
+      const key = `${comment.author}::${reply.thread_permalink}`;
+      if (existingKeys.has(key)) continue;
+
+      // Determine if this is a direct reply to the user's comment
+      const isReplyToUser = userCommentIds.has(comment.parent_id);
+
+      // Run permission detection
+      const permission = detectPermission(comment.body, isReplyToUser);
+
+      detected.push({
+        reddit_username: comment.author,
+        comment_text: comment.body,
+        comment_permalink: comment.permalink,
+        source_thread_permalink: reply.thread_permalink,
+        source_signal_id: reply.signal_id || null,
+        permission_type: permission.type,
+        permission_score: permission.score,
+        matched_pattern: permission.matchedPattern,
+      });
+
+      // Mark as tracked to avoid duplicates within this scan
+      existingKeys.add(key);
+    }
+  }
+
+  return detected;
+}

--- a/app/src/lib/reddit/fetcher.ts
+++ b/app/src/lib/reddit/fetcher.ts
@@ -174,6 +174,79 @@ export async function fetchSubredditInfo(subreddit: string): Promise<RedditSubre
   }
 }
 
+// ---- Thread Comments Cache (shorter TTL for monitoring) ----
+const commentCache = new Map<string, { data: ThreadComment[]; expiresAt: number }>();
+const COMMENT_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+export function clearCommentCache() {
+  commentCache.clear();
+}
+
+interface ThreadComment {
+  id: string;
+  author: string;
+  body: string;
+  score: number;
+  created_utc: number;
+  permalink: string;
+  parent_id: string;
+}
+
+function flattenComments(children: Record<string, unknown>[]): ThreadComment[] {
+  const results: ThreadComment[] = [];
+  for (const child of children) {
+    if ((child as { kind?: string }).kind !== 't1') continue;
+    const data = child.data as Record<string, unknown>;
+    if (!data || !data.author || data.author === '[deleted]') continue;
+
+    results.push({
+      id: data.name as string, // full thing ID e.g. "t1_abc123"
+      author: data.author as string,
+      body: (data.body as string) || '',
+      score: (data.score as number) || 0,
+      created_utc: (data.created_utc as number) || 0,
+      permalink: (data.permalink as string) || '',
+      parent_id: (data.parent_id as string) || '',
+    });
+
+    // Recurse into replies
+    const replies = data.replies as { data?: { children?: Record<string, unknown>[] } } | undefined;
+    if (replies?.data?.children) {
+      results.push(...flattenComments(replies.data.children));
+    }
+  }
+  return results;
+}
+
+export async function fetchThreadComments(permalink: string): Promise<ThreadComment[]> {
+  const cacheKey = `comments:${permalink}`;
+  const cached = commentCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.data;
+  }
+  if (cached) commentCache.delete(cacheKey);
+
+  try {
+    // Ensure permalink doesn't have trailing slash issues
+    const cleanPermalink = permalink.endsWith('/') ? permalink.slice(0, -1) : permalink;
+    const url = `${REDDIT_BASE}${cleanPermalink}.json?limit=200&sort=new&raw_json=1`;
+    const json = await fetchFromReddit(url) as unknown[];
+
+    // Reddit returns [post_listing, comments_listing]
+    if (!Array.isArray(json) || json.length < 2) return [];
+
+    const commentsListing = json[1] as { data?: { children?: Record<string, unknown>[] } };
+    const children = commentsListing?.data?.children || [];
+    const comments = flattenComments(children);
+
+    commentCache.set(cacheKey, { data: comments, expiresAt: Date.now() + COMMENT_CACHE_TTL });
+    return comments;
+  } catch (error) {
+    console.error('Failed to fetch thread comments:', error);
+    return [];
+  }
+}
+
 export async function searchSubredditPosts(
   subreddit: string,
   query: string,

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -331,6 +331,66 @@ export interface SubredditRule {
   analyzed_at: string;
 }
 
+// ---- DM Workflow types ----
+
+export type DmPipelineStage =
+  | 'detected'
+  | 'dm_ready'
+  | 'draft_generated'
+  | 'dm_sent'
+  | 'responded'
+  | 'converted'
+  | 'closed';
+
+export type PermissionType = 'explicit_dm_request' | 'positive_reply' | 'passive_commenter';
+
+export interface OutreachDM {
+  id: string;
+  project_id: string;
+  reddit_username: string;
+  comment_text: string | null;
+  comment_permalink: string | null;
+  source_thread_permalink: string;
+  source_signal_id: string | null;
+  permission_type: PermissionType;
+  permission_score: number;
+  matched_pattern: string | null;
+  pipeline_stage: DmPipelineStage;
+  dm_subject: string | null;
+  dm_body: string | null;
+  dm_template_id: string | null;
+  dm_sent_at: string | null;
+  follow_up_due: string | null;
+  touch_number: number;
+  outcome: string | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+  signal?: {
+    title: string;
+    subreddit: string;
+    permalink: string;
+  } | null;
+}
+
+export interface DmTemplate {
+  id: string;
+  name: string;
+  description: string;
+  subject_hint: string;
+  body_hint: string;
+}
+
+export interface ThreadComment {
+  id: string;
+  author: string;
+  body: string;
+  score: number;
+  created_utc: number;
+  permalink: string;
+  parent_id: string;
+}
+
 // ---- GitHub types ----
 
 export interface GitHubCommit {

--- a/app/supabase/migrations/007_outreach_dms.sql
+++ b/app/supabase/migrations/007_outreach_dms.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- 007_outreach_dms.sql — DM workflow manager table + RLS
+-- ============================================================
+
+create table if not exists outreach_dms (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references projects(id) on delete cascade,
+  reddit_username text not null,
+  comment_text text,
+  comment_permalink text,
+  source_thread_permalink text not null,
+  source_signal_id uuid references outreach_signals(id) on delete set null,
+  permission_type text not null default 'passive_commenter',
+  permission_score real default 0.3,
+  matched_pattern text,
+  pipeline_stage text not null default 'detected',
+  dm_subject text,
+  dm_body text,
+  dm_template_id text,
+  dm_sent_at timestamptz,
+  follow_up_due timestamptz,
+  touch_number integer default 0,
+  outcome text,
+  notes text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  constraint outreach_dms_unique_lead unique (project_id, reddit_username, source_thread_permalink)
+);
+
+alter table outreach_dms enable row level security;
+
+create policy "Users can manage their own outreach DMs"
+  on outreach_dms for all
+  using (project_id in (select id from projects where user_id = auth.uid()))
+  with check (project_id in (select id from projects where user_id = auth.uid()));
+
+-- Indexes
+create index if not exists idx_outreach_dms_project_stage on outreach_dms(project_id, pipeline_stage);
+create index if not exists idx_outreach_dms_follow_up on outreach_dms(follow_up_due) where follow_up_due is not null;
+create index if not exists idx_outreach_dms_created on outreach_dms(project_id, created_at desc);
+
+-- updated_at trigger
+create trigger outreach_dms_updated_at
+  before update on outreach_dms
+  for each row execute function update_updated_at();


### PR DESCRIPTION
## Summary
- Adds a full DM workflow pipeline as the 4th Outreach sub-page: monitors tracked threads for interested commenters, classifies permission signals (explicit DM requests, positive replies, passive commenters), and generates AI-powered DM drafts
- 3-tier regex permission detector scores commenters by intent — "DM me" → 0.95, positive reply to user → 0.75, passive commenter → 0.30
- "Copy & Open DM" constructs Reddit's native compose URL pre-filled with subject + body; tab-return confirmation prompt tracks send status with configurable follow-up reminders
- Pipeline stages (detected → dm_ready → draft_generated → dm_sent → responded → converted → closed) with quick-action buttons, stats dashboard, filter tabs, and follow-up due banner

## Test plan
- [ ] Run migration `007_outreach_dms.sql` in Supabase SQL editor
- [ ] Verify "DMs" appears as 4th item under Outreach in sidebar
- [ ] Seed a tracked reply and click "Scan Threads" — verify commenters appear as DM lead cards
- [ ] Check permission badges: green "DM requested" for explicit asks, blue "Positive reply" for replies to user, gray "Commenter" for others
- [ ] Expand a card → Generate DM → verify subject + body appear
- [ ] Click "Copy & Open DM" → verify Reddit compose URL opens pre-filled
- [ ] Return to tab → verify "Did you send the DM?" confirmation appears
- [ ] Confirm send → verify pipeline stage updates to "dm_sent" and follow-up timer starts
- [ ] Test quick actions: "Got a reply", "No response", "Converted"
- [ ] Verify filter tabs (All, Ready, Drafted, Sent, Responded) filter correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)