### PR TITLE
Add profile image upload with hover popover

### DIFF
--- a/app/src/app/api/profile/avatar/route.ts
+++ b/app/src/app/api/profile/avatar/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST(req: NextRequest) {
+  const supabase = await createClient();
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const formData = await req.formData();
+  const file = formData.get('file') as File | null;
+
+  if (!file) {
+    return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+  }
+
+  if (!file.type.startsWith('image/')) {
+    return NextResponse.json({ error: 'File must be an image' }, { status: 400 });
+  }
+
+  // 5MB limit
+  if (file.size > 5 * 1024 * 1024) {
+    return NextResponse.json({ error: 'File must be under 5MB' }, { status: 400 });
+  }
+
+  const ext = file.name.split('.').pop() || 'jpg';
+  const filePath = `${user.id}/avatar.${ext}`;
+
+  // Upload to Supabase Storage (upsert to overwrite previous avatar)
+  const { error: uploadError } = await supabase.storage
+    .from('avatars')
+    .upload(filePath, file, { upsert: true, contentType: file.type });
+
+  if (uploadError) {
+    return NextResponse.json({ error: 'Upload failed: ' + uploadError.message }, { status: 500 });
+  }
+
+  // Get public URL
+  const { data: urlData } = supabase.storage
+    .from('avatars')
+    .getPublicUrl(filePath);
+
+  const avatarUrl = urlData.publicUrl + '?t=' + Date.now();
+
+  // Update profile
+  const { error: updateError } = await supabase
+    .from('profiles')
+    .update({ avatar_url: avatarUrl, updated_at: new Date().toISOString() })
+    .eq('id', user.id);
+
+  if (updateError) {
+    return NextResponse.json({ error: 'Failed to update profile' }, { status: 500 });
+  }
+
+  return NextResponse.json({ avatar_url: avatarUrl });
+}
+
+export async function DELETE() {
+  const supabase = await createClient();
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // List and remove all files in the user's avatar folder
+  const { data: files } = await supabase.storage
+    .from('avatars')
+    .list(user.id);
+
+  if (files?.length) {
+    await supabase.storage
+      .from('avatars')
+      .remove(files.map((f) => `${user.id}/${f.name}`));
+  }
+
+  // Clear avatar_url on profile
+  await supabase
+    .from('profiles')
+    .update({ avatar_url: null, updated_at: new Date().toISOString() })
+    .eq('id', user.id);
+
+  return NextResponse.json({ success: true });
+}

--- a/app/src/app/projects/page.tsx
+++ b/app/src/app/projects/page.tsx
@@ -25,8 +25,8 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { ThemeToggle } from '@/components/ui/theme-toggle';
+import { AvatarUpload } from '@/components/profile/AvatarUpload';
 import { FadeIn } from '@/components/motion';
 import { staggerContainerVariants, staggerItemVariants, cardHover, cardTap } from '@/lib/motion';
 import type { Project } from '@/types';
@@ -40,7 +40,6 @@ export default function ProjectsPage() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingProject, setEditingProject] = useState<Project | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const [email, setEmail] = useState('');
   const router = useRouter();
 
   // Edit form state
@@ -55,9 +54,6 @@ export default function ProjectsPage() {
 
   useEffect(() => {
     loadProjects();
-    supabase.auth.getUser().then(({ data }) => {
-      if (data.user) setEmail(data.user.email || '');
-    });
   }, []);
 
   async function loadProjects() {
@@ -153,11 +149,7 @@ export default function ProjectsPage() {
         </div>
         <div className="flex items-center gap-3">
           <ThemeToggle />
-          <Avatar className="h-8 w-8">
-            <AvatarFallback className="text-xs">
-              {email ? email[0].toUpperCase() : 'U'}
-            </AvatarFallback>
-          </Avatar>
+          <AvatarUpload />
           <button
             onClick={handleLogout}
             className="text-muted-foreground hover:text-foreground transition-colors"

--- a/app/src/components/chat/ChatInterface.tsx
+++ b/app/src/components/chat/ChatInterface.tsx
@@ -7,8 +7,9 @@ import { Send, Loader2, Bot, User, FileText, X, ArrowUp, MessageSquare, Check, P
 import { motion } from 'motion/react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
-import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { scaleFadeVariants, staggerContainerVariants, staggerItemVariants, fadeUpVariants } from '@/lib/motion';
+import { useProfileStore } from '@/stores/profile-store';
 import type { Project } from '@/types';
 import type { ReferencePost } from '@/stores/create-store';
 
@@ -158,6 +159,7 @@ export function ChatInterface({
   emptyTitle = 'SuperReddit AI',
   emptyDescription = 'Your Reddit marketing strategist. Ask about subreddit targeting, post writing, engagement strategies, and avoiding bans.',
 }: ChatInterfaceProps) {
+  const { avatarUrl: profileAvatarUrl, fetchProfile } = useProfileStore();
   const [messages, setMessages] = useState<Message[]>(initialMessages);
   const [input, setInput] = useState('');
   const [pendingImages, setPendingImages] = useState<ImageAttachment[]>([]);
@@ -165,6 +167,8 @@ export function ChatInterface({
   const scrollRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { fetchProfile(); }, [fetchProfile]);
 
   useEffect(() => {
     scrollToBottom();
@@ -515,6 +519,7 @@ export function ChatInterface({
                   </div>
                   {message.role === 'user' && (
                     <Avatar className="h-6 w-6 shrink-0 mt-0.5">
+                      {profileAvatarUrl && <AvatarImage src={profileAvatarUrl} alt="You" />}
                       <AvatarFallback className="text-xs">
                         <User className="h-3 w-3" />
                       </AvatarFallback>

--- a/app/src/components/layout/header.tsx
+++ b/app/src/components/layout/header.tsx
@@ -1,29 +1,20 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { createClient } from '@/lib/supabase/client';
-import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { AvatarUpload } from '@/components/profile/AvatarUpload';
+import { useProfileStore } from '@/stores/profile-store';
+import { useEffect } from 'react';
 
 export function Header({ title }: { title?: string }) {
-  const [email, setEmail] = useState<string>('');
+  const { email, fetchProfile } = useProfileStore();
 
-  useEffect(() => {
-    const supabase = createClient();
-    supabase.auth.getUser().then(({ data }) => {
-      if (data.user) setEmail(data.user.email || '');
-    });
-  }, []);
+  useEffect(() => { fetchProfile(); }, [fetchProfile]);
 
   return (
     <header className="flex h-14 items-center justify-between border-b bg-card px-6">
       <h1 className="text-lg font-semibold">{title || 'SuperReddit'}</h1>
       <div className="flex items-center gap-3">
         <span className="text-sm text-muted-foreground">{email}</span>
-        <Avatar className="h-8 w-8">
-          <AvatarFallback className="text-xs">
-            {email ? email[0].toUpperCase() : 'U'}
-          </AvatarFallback>
-        </Avatar>
+        <AvatarUpload />
       </div>
     </header>
   );

--- a/app/src/components/layout/project-sidebar.tsx
+++ b/app/src/components/layout/project-sidebar.tsx
@@ -32,6 +32,7 @@ import { motion, AnimatePresence } from 'motion/react';
 import { createClient } from '@/lib/supabase/client';
 import { cn } from '@/lib/utils';
 import { ThemeToggle } from '@/components/ui/theme-toggle';
+import { AvatarUpload } from '@/components/profile/AvatarUpload';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { staggerContainerVariants, staggerItemVariants } from '@/lib/motion';
 import type { Project } from '@/types';
@@ -333,6 +334,16 @@ export function ProjectSidebar({ project }: { project: Project }) {
 
         {/* Bottom */}
         <div className={cn('border-t space-y-1', collapsed ? 'p-1.5' : 'p-3')}>
+          {/* Avatar */}
+          {collapsed ? (
+            <div className="flex justify-center py-1">
+              <AvatarUpload size="sm" />
+            </div>
+          ) : (
+            <div className="rounded-lg px-3 py-2">
+              <AvatarUpload showName />
+            </div>
+          )}
           {collapsed ? (
             <Tooltip>
               <TooltipTrigger asChild>

--- a/app/src/components/profile/AvatarUpload.tsx
+++ b/app/src/components/profile/AvatarUpload.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useRef, useState, useEffect, useCallback } from 'react';
+import { Loader2, Upload, Trash2 } from 'lucide-react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Button } from '@/components/ui/button';
+import { useProfileStore } from '@/stores/profile-store';
+import { cn } from '@/lib/utils';
+import { toast } from 'sonner';
+
+interface AvatarUploadProps {
+  size?: 'sm' | 'default' | 'lg';
+  showName?: boolean;
+}
+
+export function AvatarUpload({ size = 'default', showName = false }: AvatarUploadProps) {
+  const { email, avatarUrl, fetchProfile, setAvatarUrl } = useProfileStore();
+  const [uploading, setUploading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => { fetchProfile(); }, [fetchProfile]);
+
+  const fallback = email ? email[0].toUpperCase() : 'U';
+
+  const handleEnter = useCallback(() => {
+    if (closeTimer.current) { clearTimeout(closeTimer.current); closeTimer.current = null; }
+    setOpen(true);
+  }, []);
+
+  const handleLeave = useCallback(() => {
+    closeTimer.current = setTimeout(() => setOpen(false), 200);
+  }, []);
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    e.target.value = '';
+
+    if (!file.type.startsWith('image/')) {
+      toast.error('Please select an image file');
+      return;
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error('Image must be under 5MB');
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const res = await fetch('/api/profile/avatar', { method: 'POST', body: formData });
+      const data = await res.json();
+
+      if (!res.ok) {
+        toast.error(data.error || 'Upload failed');
+        return;
+      }
+
+      setAvatarUrl(data.avatar_url);
+      toast.success('Profile image updated');
+      setOpen(false);
+    } catch {
+      toast.error('Upload failed');
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  async function handleRemove() {
+    setUploading(true);
+    try {
+      const res = await fetch('/api/profile/avatar', { method: 'DELETE' });
+      if (!res.ok) {
+        toast.error('Failed to remove image');
+        return;
+      }
+      setAvatarUrl('');
+      toast.success('Profile image removed');
+      setOpen(false);
+    } catch {
+      toast.error('Failed to remove image');
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  const sizeClasses = {
+    sm: 'h-6 w-6',
+    default: 'h-8 w-8',
+    lg: 'h-10 w-10',
+  };
+
+  return (
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        onChange={handleFileChange}
+        className="hidden"
+      />
+      <Popover open={open} onOpenChange={setOpen}>
+        <div onMouseEnter={handleEnter} onMouseLeave={handleLeave}>
+          <PopoverTrigger asChild>
+            <button
+              className={cn(
+                'group relative rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                showName ? 'flex items-center gap-3' : '',
+                sizeClasses[size],
+                showName && 'w-auto h-auto',
+              )}
+            >
+              <Avatar size={size} className={sizeClasses[size]}>
+                {avatarUrl && <AvatarImage src={avatarUrl} alt="Profile" />}
+                <AvatarFallback className="text-xs">{fallback}</AvatarFallback>
+              </Avatar>
+              {showName && (
+                <span className="text-sm font-medium truncate">{email}</span>
+              )}
+            </button>
+          </PopoverTrigger>
+        </div>
+        <PopoverContent
+          side="top"
+          align="start"
+          sideOffset={8}
+          onMouseEnter={handleEnter}
+          onMouseLeave={handleLeave}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          className="w-64 border-white/20 bg-white/10 backdrop-blur-xl dark:bg-black/20 dark:border-white/10 shadow-xl rounded-xl p-4"
+        >
+          <div className="flex flex-col items-center gap-3">
+            {/* Large preview */}
+            <Avatar className="h-20 w-20">
+              {avatarUrl && <AvatarImage src={avatarUrl} alt="Profile" />}
+              <AvatarFallback className="text-2xl">{fallback}</AvatarFallback>
+            </Avatar>
+
+            <p className="text-sm font-medium truncate max-w-full">{email}</p>
+
+            <div className="flex gap-2 w-full">
+              <Button
+                variant="outline"
+                size="sm"
+                className="flex-1 text-xs gap-1.5 bg-white/10 border-white/20 backdrop-blur-sm hover:bg-white/20 dark:bg-white/5 dark:border-white/10 dark:hover:bg-white/10"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading}
+              >
+                {uploading ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Upload className="h-3 w-3" />
+                )}
+                {avatarUrl ? 'Change' : 'Upload'}
+              </Button>
+              {avatarUrl && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-xs gap-1.5 bg-white/10 border-white/20 backdrop-blur-sm hover:bg-destructive/20 hover:text-destructive hover:border-destructive/30 dark:bg-white/5 dark:border-white/10"
+                  onClick={handleRemove}
+                  disabled={uploading}
+                >
+                  <Trash2 className="h-3 w-3" />
+                </Button>
+              )}
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </>
+  );
+}
+
+/** Read-only avatar display that pulls from the shared profile store */
+export function ProfileAvatar({ size = 'default' }: { size?: 'sm' | 'default' | 'lg' }) {
+  const { email, avatarUrl, fetchProfile } = useProfileStore();
+
+  useEffect(() => { fetchProfile(); }, [fetchProfile]);
+
+  const fallback = email ? email[0].toUpperCase() : 'U';
+  const sizeClasses = { sm: 'h-6 w-6', default: 'h-8 w-8', lg: 'h-10 w-10' };
+
+  return (
+    <Avatar size={size} className={sizeClasses[size]}>
+      {avatarUrl && <AvatarImage src={avatarUrl} alt="Profile" />}
+      <AvatarFallback className="text-xs">{fallback}</AvatarFallback>
+    </Avatar>
+  );
+}

--- a/app/src/stores/profile-store.ts
+++ b/app/src/stores/profile-store.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand';
+import { createClient } from '@/lib/supabase/client';
+
+interface ProfileStore {
+  email: string;
+  avatarUrl: string | null;
+  loaded: boolean;
+  fetchProfile: () => Promise<void>;
+  setAvatarUrl: (url: string) => void;
+}
+
+export const useProfileStore = create<ProfileStore>((set, get) => ({
+  email: '',
+  avatarUrl: null,
+  loaded: false,
+
+  fetchProfile: async () => {
+    if (get().loaded) return;
+    const supabase = createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return;
+
+    set({ email: user.email || '' });
+
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('avatar_url')
+      .eq('id', user.id)
+      .single();
+
+    set({
+      avatarUrl: profile?.avatar_url || null,
+      loaded: true,
+    });
+  },
+
+  setAvatarUrl: (url) => set({ avatarUrl: url }),
+}));

--- a/app/supabase/migrations/009_avatar_storage.sql
+++ b/app/supabase/migrations/009_avatar_storage.sql
@@ -1,0 +1,37 @@
+-- Create avatars storage bucket
+insert into storage.buckets (id, name, public)
+values ('avatars', 'avatars', true)
+on conflict (id) do nothing;
+
+-- Allow authenticated users to upload their own avatar
+create policy "Users can upload own avatar"
+on storage.objects for insert
+to authenticated
+with check (
+  bucket_id = 'avatars'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- Allow authenticated users to update (overwrite) their own avatar
+create policy "Users can update own avatar"
+on storage.objects for update
+to authenticated
+using (
+  bucket_id = 'avatars'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- Allow authenticated users to delete their own avatar
+create policy "Users can delete own avatar"
+on storage.objects for delete
+to authenticated
+using (
+  bucket_id = 'avatars'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- Allow anyone to read avatars (public bucket)
+create policy "Anyone can read avatars"
+on storage.objects for select
+to public
+using (bucket_id = 'avatars');


### PR DESCRIPTION
## Summary
- Add avatar upload/change/remove via Supabase Storage with RLS policies scoped per user
- Glassmorphic hover popover (backdrop-blur, translucent) shows large preview + upload/remove buttons
- Shared Zustand profile store so avatar updates instantly across all pages (projects, sidebar, header, chat)
- API routes for POST (upload) and DELETE (remove) at `/api/profile/avatar`

Closes #20

## Test plan
- [ ] Run `supabase db push` to apply the `009_avatar_storage.sql` migration
- [ ] Hover over avatar on projects page — glassmorphic popover appears
- [ ] Upload an image — avatar updates everywhere (sidebar, header, chat)
- [ ] Remove avatar — falls back to initial letter
- [ ] Verify popover opens on hover in sidebar (both collapsed and expanded)
- [ ] Verify user avatar shows in chat message bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)