### PR TITLE
Fix signal scanning pipeline and improve signals UI

### DIFF
--- a/app/src/app/api/outreach/signals/route.ts
+++ b/app/src/app/api/outreach/signals/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { detectSignals } from '@/lib/outreach/detector';
-import { enqueueProject, getScanStatus } from '@/lib/outreach/poll-queue';
 
 export async function GET(request: NextRequest) {
   try {
@@ -48,16 +47,44 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'No subreddits configured. Add subreddits to your project first.' }, { status: 400 });
     }
 
-    // Derive keywords: use config keywords if available, otherwise auto-generate from product info
-    let keywords: string[] = (config?.keywords as string[]) || [];
+    // Derive keywords: check outreach_keywords table first, then config.keywords, then auto-generate
+    let keywords: string[] = [];
+
+    // 1. Try outreach_keywords table (managed by wizard/keyword manager)
+    try {
+      const { data: keywordRows } = await supabase
+        .from('outreach_keywords')
+        .select('phrases')
+        .eq('project_id', projectId)
+        .eq('is_active', true);
+
+      if (keywordRows?.length) {
+        keywords = keywordRows.flatMap((k: { phrases: string[] }) => k.phrases);
+      }
+    } catch {
+      // Table may not exist yet
+    }
+
+    // 2. Fall back to config.keywords
     if (keywords.length === 0) {
-      const stopWords = new Set(['the', 'a', 'an', 'is', 'are', 'was', 'were', 'be', 'been', 'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could', 'should', 'may', 'might', 'can', 'shall', 'to', 'of', 'in', 'for', 'on', 'with', 'at', 'by', 'from', 'as', 'into', 'through', 'during', 'before', 'after', 'above', 'below', 'between', 'and', 'but', 'or', 'nor', 'not', 'so', 'yet', 'both', 'either', 'neither', 'each', 'every', 'all', 'any', 'few', 'more', 'most', 'other', 'some', 'such', 'no', 'only', 'own', 'same', 'than', 'too', 'very', 'just', 'that', 'this', 'these', 'those', 'it', 'its', 'i', 'me', 'my', 'we', 'our', 'you', 'your', 'he', 'she', 'they', 'them', 'their', 'what', 'which', 'who', 'when', 'where', 'why', 'how', 'about', 'up', 'out', 'if', 'then', 'also', 'like', 'well', 'back', 'there', 'here']);
-      const text = `${project.product_name} ${project.product_description} ${project.target_audience || ''}`;
-      const words = text.toLowerCase().split(/\s+/).filter((w) => w.length > 2 && !stopWords.has(w));
-      keywords = [...new Set(words)].slice(0, 10);
+      keywords = (config?.keywords as string[]) || [];
+    }
+
+    // 3. Auto-generate from product info as last resort
+    if (keywords.length === 0) {
+      // Use the product name as a phrase keyword instead of splitting into single words
+      keywords = [project.product_name];
+      // Add target audience as a keyword if available
+      if (project.target_audience) {
+        keywords.push(project.target_audience);
+      }
     }
 
     const competitors: string[] = (config?.competitors as string[]) || [];
+
+    console.log('[Signals] Subreddits:', subNames);
+    console.log('[Signals] Keywords:', keywords);
+    console.log('[Signals] Competitors:', competitors);
 
     // Check if we need to detect new signals (if none exist or latest is older than 30 min)
     let latestSignal: { fetched_at: string } | null = null;
@@ -118,65 +145,25 @@ export async function GET(request: NextRequest) {
         // Table may not exist yet, skip product context
       }
 
-      // Try queue-based scanning first (non-blocking), fall back to inline
-      let queued = false;
-      if (forceRefresh) {
-        try {
-          await enqueueProject(supabase, projectId, 'high');
-          const scanStatus = await getScanStatus(supabase, projectId);
-          if (scanStatus.status === 'queued' || scanStatus.status === 'processing') {
-            queued = true;
-          }
-        } catch {
-          // Queue table may not exist — fall back to inline detection
-        }
-      }
-
-      if (!queued) {
-        // Inline detection as fallback (or for stale non-force requests)
-        try {
-          await detectSignals(supabase, {
-            projectId,
-            keywords,
-            competitors,
-            subreddits: subNames,
-            subredditLimit: (config?.subreddit_limit as number) || 20,
-            productName: project.product_name,
-            productDescription: project.product_description,
-            productContext: productContextOption,
-            timeFilter: effectiveTimeFilter as 'hour' | 'day' | 'week' | 'month' | 'year' | 'all',
-            maxResults: effectiveMaxResults,
-            includeComments: effectiveIncludeComments,
-          });
-        } catch (detectError) {
-          console.error('Signal detection error:', detectError);
-          // Detection failed but we can still return existing signals
-        }
-      }
-
-      // If queued, return queue status so frontend can poll
-      if (queued) {
-        const scanStatus = await getScanStatus(supabase, projectId);
-
-        // Still return existing signals along with queue status
-        try {
-          const { data: existingSignals } = await supabase
-            .from('outreach_signals')
-            .select('*')
-            .eq('project_id', projectId)
-            .order('combined_score', { ascending: false })
-            .limit(100);
-
-          return NextResponse.json({
-            signals: existingSignals || [],
-            scanStatus: scanStatus,
-          });
-        } catch {
-          return NextResponse.json({
-            signals: [],
-            scanStatus: scanStatus,
-          });
-        }
+      // Always run inline detection for immediate results.
+      // Queue-based scanning is handled by the cron job (/api/cron/poll-signals).
+      try {
+        await detectSignals(supabase, {
+          projectId,
+          keywords,
+          competitors,
+          subreddits: subNames,
+          subredditLimit: (config?.subreddit_limit as number) || 20,
+          productName: project.product_name,
+          productDescription: project.product_description,
+          productContext: productContextOption,
+          timeFilter: effectiveTimeFilter as 'hour' | 'day' | 'week' | 'month' | 'year' | 'all',
+          maxResults: effectiveMaxResults,
+          includeComments: effectiveIncludeComments,
+        });
+      } catch (detectError) {
+        console.error('Signal detection error:', detectError);
+        // Detection failed but we can still return existing signals
       }
     }
 

--- a/app/src/app/projects/[id]/outreach/signals/page.tsx
+++ b/app/src/app/projects/[id]/outreach/signals/page.tsx
@@ -12,6 +12,7 @@ import { Badge } from '@/components/ui/badge';
 import { SignalCard } from '@/components/outreach/SignalCard';
 import { ScanParametersModal } from '@/components/outreach/ScanParametersModal';
 import { ScanWizard } from '@/components/outreach/ScanWizard';
+import { TooltipProvider } from '@/components/ui/tooltip';
 import { toast } from 'sonner';
 import type { OutreachSignal } from '@/types';
 
@@ -32,6 +33,7 @@ export default function OutreachSignalsPage() {
   const [lastScanned, setLastScanned] = useState<string | null>(null);
 
   const [subFilter, setSubFilter] = useState<string | null>(null);
+  const [tierFilter, setTierFilter] = useState<'hot' | 'warm' | 'unseen' | null>(null);
 
   // Wizard & modal state
   const [wizardOpen, setWizardOpen] = useState(false);
@@ -202,7 +204,21 @@ export default function OutreachSignalsPage() {
     return `${Math.floor(seconds / 3600)}h ago`;
   }
 
-  const maxSubCount = analytics?.topSubreddits?.[0]?.count || 1;
+  // Client-side tier filtering (matches analytics derivation logic)
+  const filteredSignals = tierFilter
+    ? signals.filter((s) => {
+        if (tierFilter === 'unseen') return s.is_unseen;
+        // Derive tier from lead_tier or combined_score
+        let tier = s.lead_tier;
+        if (!tier) {
+          const score = s.combined_score ?? 0;
+          if (score >= 0.7) tier = 'hot';
+          else if (score >= 0.4) tier = 'warm';
+          else tier = 'cold';
+        }
+        return tier === tierFilter;
+      })
+    : signals;
 
   return (
     <PageTransition>
@@ -213,28 +229,48 @@ export default function OutreachSignalsPage() {
 
             {/* Analytics Row */}
             <div className="grid grid-cols-4 gap-3">
-              <Card className="p-4 flex flex-col gap-1">
+              <Card
+                className={`p-4 flex flex-col gap-1 cursor-pointer transition-colors ${
+                  tierFilter === 'hot' ? 'ring-2 ring-red-500 bg-red-500/5' : 'hover:bg-accent/50'
+                }`}
+                onClick={() => setTierFilter(tierFilter === 'hot' ? null : 'hot')}
+              >
                 <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">Hot Leads</span>
                 <span className="text-3xl font-bold text-red-500">{analytics?.hotCount ?? '-'}</span>
                 <span className="text-[11px] text-muted-foreground flex items-center gap-1">
                   <Flame className="h-3 w-3 text-red-500" /> high conversion
                 </span>
               </Card>
-              <Card className="p-4 flex flex-col gap-1">
+              <Card
+                className={`p-4 flex flex-col gap-1 cursor-pointer transition-colors ${
+                  tierFilter === 'warm' ? 'ring-2 ring-amber-500 bg-amber-500/5' : 'hover:bg-accent/50'
+                }`}
+                onClick={() => setTierFilter(tierFilter === 'warm' ? null : 'warm')}
+              >
                 <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">Warm Leads</span>
                 <span className="text-3xl font-bold text-amber-500">{analytics?.warmCount ?? '-'}</span>
                 <span className="text-[11px] text-muted-foreground flex items-center gap-1">
                   <Sun className="h-3 w-3 text-amber-500" /> potential leads
                 </span>
               </Card>
-              <Card className="p-4 flex flex-col gap-1">
+              <Card
+                className={`p-4 flex flex-col gap-1 cursor-pointer transition-colors ${
+                  tierFilter === 'unseen' ? 'ring-2 ring-blue-500 bg-blue-500/5' : 'hover:bg-accent/50'
+                }`}
+                onClick={() => setTierFilter(tierFilter === 'unseen' ? null : 'unseen')}
+              >
                 <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">Unseen</span>
                 <span className="text-3xl font-bold text-blue-500">{analytics?.unseenCount ?? '-'}</span>
                 <span className="text-[11px] text-muted-foreground flex items-center gap-1">
                   <Eye className="h-3 w-3 text-blue-500" /> needs review
                 </span>
               </Card>
-              <Card className="p-4 flex flex-col gap-1">
+              <Card
+                className={`p-4 flex flex-col gap-1 cursor-pointer transition-colors ${
+                  tierFilter === null ? 'ring-2 ring-border' : 'hover:bg-accent/50'
+                }`}
+                onClick={() => setTierFilter(null)}
+              >
                 <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">Total Signals</span>
                 <span className="text-3xl font-bold">{analytics?.totalCount ?? '-'}</span>
                 <span className="text-[11px] text-muted-foreground flex items-center gap-1">
@@ -246,30 +282,37 @@ export default function OutreachSignalsPage() {
             {/* Top Subreddits */}
             {analytics?.topSubreddits && analytics.topSubreddits.length > 0 && (
               <div>
-                <h3 className="text-[13px] font-semibold text-muted-foreground mb-2.5">Top Subreddits</h3>
+                <h3 className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-3">Top Subreddits</h3>
                 <div className="flex gap-2 flex-wrap">
-                  {analytics.topSubreddits.map((sub) => (
-                    <button
-                      key={sub.name}
-                      onClick={() => setSubFilter(subFilter === sub.name ? null : sub.name)}
-                      className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
-                        subFilter === sub.name
-                          ? 'border-primary bg-primary/10 text-primary'
-                          : 'border-border bg-card hover:bg-accent text-foreground'
-                      }`}
-                    >
-                      <span>r/{sub.name}</span>
-                      <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-4 font-semibold">
-                        {sub.count}
-                      </Badge>
-                      <div className="w-8 h-1 rounded-full bg-muted overflow-hidden">
-                        <div
-                          className="h-full rounded-full bg-indigo-500"
-                          style={{ width: `${(sub.count / maxSubCount) * 100}%` }}
-                        />
-                      </div>
-                    </button>
-                  ))}
+                  {analytics.topSubreddits.slice(0, 6).map((sub, i) => {
+                    const isActive = subFilter === sub.name;
+                    const pct = analytics.totalCount > 0
+                      ? ((sub.count / analytics.totalCount) * 100).toFixed(1)
+                      : '0';
+                    const rankColors = ['text-rose-400', 'text-amber-400', 'text-emerald-400'];
+                    return (
+                      <button
+                        key={sub.name}
+                        onClick={() => setSubFilter(isActive ? null : sub.name)}
+                        className={`relative rounded-lg border px-3 py-2 text-left transition-colors ${
+                          isActive
+                            ? 'border-primary bg-primary/5'
+                            : 'border-border bg-card hover:bg-accent/50'
+                        }`}
+                      >
+                        <span className={`absolute top-1 right-2 text-[9px] font-bold ${rankColors[i] || 'text-muted-foreground/50'}`}>
+                          #{i + 1}
+                        </span>
+                        <div className="flex items-baseline gap-1.5">
+                          <span className="text-lg font-bold tabular-nums">{sub.count}</span>
+                          <span className="text-xs font-semibold truncate">r/{sub.name}</span>
+                        </div>
+                        <p className="text-[10px] text-muted-foreground">
+                          leads &bull; <span className="font-semibold text-emerald-500">{pct}%</span>
+                        </p>
+                      </button>
+                    );
+                  })}
                 </div>
               </div>
             )}
@@ -312,7 +355,8 @@ export default function OutreachSignalsPage() {
             <div className="flex items-center gap-2">
               <h2 className="text-[15px] font-semibold">Leads</h2>
               <span className="text-xs text-muted-foreground">
-                {loading ? '...' : `${signals.length} signals`}
+                {loading ? '...' : `${filteredSignals.length} signals`}
+                {tierFilter && ` (${tierFilter})`}
               </span>
             </div>
 
@@ -323,24 +367,26 @@ export default function OutreachSignalsPage() {
                   <Skeleton key={i} className="h-72 rounded-xl" />
                 ))}
               </div>
-            ) : signals.length === 0 ? (
+            ) : filteredSignals.length === 0 ? (
               <div className="py-12 text-center text-muted-foreground">
                 No signals found. Try adjusting filters or use &quot;Scan Now&quot; to find new leads.
               </div>
             ) : (
-              <StaggerList className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                {signals.map((signal) => (
-                  <StaggerItem key={signal.id}>
-                    <SignalCard
-                      signal={signal}
-                      projectId={project.id}
-                      onStatusChange={handleStatusChange}
-                      onFavoriteToggle={handleFavoriteToggle}
-                      onMarkSeen={handleMarkSeen}
-                    />
-                  </StaggerItem>
-                ))}
-              </StaggerList>
+              <TooltipProvider>
+                <StaggerList className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                  {filteredSignals.map((signal) => (
+                    <StaggerItem key={signal.id}>
+                      <SignalCard
+                        signal={signal}
+                        projectId={project.id}
+                        onStatusChange={handleStatusChange}
+                        onFavoriteToggle={handleFavoriteToggle}
+                        onMarkSeen={handleMarkSeen}
+                      />
+                    </StaggerItem>
+                  ))}
+                </StaggerList>
+              </TooltipProvider>
             )}
           </div>
         </div>

--- a/app/src/components/outreach/SignalCard.tsx
+++ b/app/src/components/outreach/SignalCard.tsx
@@ -77,8 +77,9 @@ const tierConfig: Record<LeadTier, { label: string; badge: string; stripe: strin
 function deriveTier(signal: OutreachSignal): LeadTier {
   if (signal.lead_tier) return signal.lead_tier;
   // Backward compat: derive from combined_score
-  if (signal.combined_score >= 0.7) return 'hot';
-  if (signal.combined_score >= 0.4) return 'warm';
+  const score = signal.combined_score ?? 0;
+  if (score >= 0.7) return 'hot';
+  if (score >= 0.4) return 'warm';
   return 'cold';
 }
 
@@ -95,6 +96,7 @@ function scoreBarColor(value: number): string {
 }
 
 const timeAgo = (timestamp: number) => {
+  if (!timestamp) return '';
   const seconds = Math.floor(Date.now() / 1000 - timestamp);
   if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
   if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
@@ -157,11 +159,15 @@ export function SignalCard({ signal, projectId, onStatusChange, onFavoriteToggle
 
   return (
     <motion.div whileHover={cardHover} whileTap={cardTap} className="h-full" onClick={handleCardClick}>
-      <Card className={`transition-shadow hover:shadow-md h-full flex flex-col relative overflow-hidden ${signal.is_unseen === true ? 'border-l-[3px] border-l-blue-500' : ''}`}>
-        {/* Tier stripe */}
-        {tier !== 'cold' && (
-          <div className={`h-[3px] w-full ${config.stripe}`} />
-        )}
+      <Card className={`transition-shadow hover:shadow-md h-full flex flex-col relative overflow-hidden ${
+        tier === 'hot'
+          ? 'border-red-500/60 border-[1.5px]'
+          : tier === 'warm'
+            ? 'border-amber-500/60 border-[1.5px]'
+            : signal.is_unseen === true
+              ? 'border-l-[3px] border-l-blue-500'
+              : ''
+      }`}>
 
         <CardContent className="p-4 flex flex-col flex-1 space-y-2.5">
           {/* Header row: tier + intent + comment badge + actions */}
@@ -238,6 +244,11 @@ export function SignalCard({ signal, projectId, onStatusChange, onFavoriteToggle
             </div>
           )}
 
+          {/* Subreddit */}
+          <span className="inline-flex items-center self-start rounded-md bg-indigo-500/10 border border-indigo-500/20 px-2 py-0.5 text-[11px] font-semibold text-indigo-400">
+            r/{signal.subreddit}
+          </span>
+
           {/* Title */}
           <a
             href={`https://reddit.com${signal.permalink}`}
@@ -266,7 +277,7 @@ export function SignalCard({ signal, projectId, onStatusChange, onFavoriteToggle
           ) : (
             <div className="flex items-center gap-2">
               <span className={`text-xs font-mono font-semibold ${signal.combined_score >= 0.7 ? 'text-green-600 dark:text-green-400' : signal.combined_score >= 0.4 ? 'text-amber-600 dark:text-amber-400' : 'text-gray-500'}`}>
-                Score: {signal.combined_score.toFixed(2)}
+                Score: {(signal.combined_score ?? 0).toFixed(2)}
               </span>
             </div>
           )}
@@ -292,7 +303,6 @@ export function SignalCard({ signal, projectId, onStatusChange, onFavoriteToggle
 
           {/* Meta row */}
           <div className="flex items-center gap-2 text-[11px] text-muted-foreground flex-wrap">
-            <span className="text-[11px] text-muted-foreground/70">r/{signal.subreddit}</span>
             <span className="flex items-center gap-0.5">
               <ArrowUpRight className="h-3 w-3 text-orange-500" />
               {formatNumber(signal.score)}

--- a/app/src/lib/outreach/detector.ts
+++ b/app/src/lib/outreach/detector.ts
@@ -6,7 +6,7 @@
  * Background polling uses batch API; manual "Scan Now" uses real-time API.
  */
 
-import { searchMultiSubPosts } from '@/lib/reddit/fetcher';
+import { searchMultiSubPosts, fetchSubredditPosts } from '@/lib/reddit/fetcher';
 import { tier1Score, findCompetitorMentions } from '@/lib/outreach/signal-patterns';
 import {
   classifyPostsRealtime,
@@ -80,6 +80,10 @@ export async function detectSignals(
   let cachedPosts = await getCachedSearch(supabase, cacheKey);
   let cachedCommentPosts = await getCachedSearch(supabase, commentCacheKey);
 
+  // Invalidate cached empty results — they indicate a failed search, not "no data"
+  if (cachedPosts && cachedPosts.length === 0) cachedPosts = null;
+  if (cachedCommentPosts && cachedCommentPosts.length === 0) cachedCommentPosts = null;
+
   // Fetch from APIs if not cached
   const fetchPromises: Promise<void>[] = [];
 
@@ -91,8 +95,10 @@ export async function detectSignals(
         maxPages: 3,
       }).then(async (result) => {
         cachedPosts = result.posts;
-        // Write to L2 cache
-        await setCachedSearch(supabase, cacheKey, cachedPosts, 'reddit');
+        // Only cache non-empty results to avoid poisoning future scans
+        if (cachedPosts.length > 0) {
+          await setCachedSearch(supabase, cacheKey, cachedPosts, 'reddit');
+        }
       })
     );
   }
@@ -135,6 +141,22 @@ export async function detectSignals(
 
   if (fetchPromises.length > 0) {
     await Promise.all(fetchPromises);
+  }
+
+  console.log('[Detector] Reddit posts fetched:', cachedPosts?.length ?? 0, '| Comments fetched:', cachedCommentPosts?.length ?? 0);
+
+  // Fallback: if keyword search returned 0 posts, browse subreddit new posts directly.
+  // Uses multi-sub URL to fetch from all subreddits in a single request (fast).
+  if ((!cachedPosts || cachedPosts.length === 0) && subreddits.length > 0) {
+    console.log('[Detector] Keyword search returned 0 posts — falling back to browsing subreddit posts');
+    try {
+      const multiSub = subreddits.slice(0, 25).join('+');
+      const result = await fetchSubredditPosts(multiSub, 'new', timeFilter, Math.min(maxResults, 100));
+      cachedPosts = result.posts;
+    } catch {
+      cachedPosts = [];
+    }
+    console.log('[Detector] Fallback fetched', cachedPosts.length, 'posts from subreddit browsing');
   }
 
   // Merge posts and comments, deduplicate by ID
@@ -184,55 +206,60 @@ export async function detectSignals(
         num_comments: r.post.num_comments,
       }));
 
-    if (useV2) {
-      // V2: Product-context-aware multi-dimensional classification
-      const results = await classifyPostsV2(
-        classificationInputs,
-        {
-          productName,
-          productDescription,
-          problemsSolved: productContext.problemsSolved,
-          solutionFeatures: productContext.solutionFeatures,
-          audienceBehaviors: productContext.audienceBehaviors,
-          competitors,
-          competitorWeaknesses: productContext.competitorWeaknesses,
-        }
-      );
-
-      for (const r of results) {
-        v2Classifications.set(r.reddit_id, r);
-      }
-    } else {
-      // V1: Original classification pipeline
-      const results = await classifyPostsRealtime(
-        classificationInputs,
-        productName,
-        productDescription,
-        competitors
-      );
-
-      for (const r of results) {
-        aiClassifications.set(r.reddit_id, r);
-      }
-
-      // 4. Sonnet fallback for ambiguous results (medium bin)
-      const ambiguous = results.filter((r) => r.score_bin === 'medium');
-      if (ambiguous.length > 0) {
-        const ambiguousInputs = classificationInputs.filter((i) =>
-          ambiguous.some((a) => a.reddit_id === i.reddit_id)
+    try {
+      if (useV2) {
+        // V2: Product-context-aware multi-dimensional classification
+        const results = await classifyPostsV2(
+          classificationInputs,
+          {
+            productName,
+            productDescription,
+            problemsSolved: productContext.problemsSolved,
+            solutionFeatures: productContext.solutionFeatures,
+            audienceBehaviors: productContext.audienceBehaviors,
+            competitors,
+            competitorWeaknesses: productContext.competitorWeaknesses,
+          }
         );
 
-        const sonnetResults = await reclassifyWithSonnet(
-          ambiguousInputs,
+        for (const r of results) {
+          v2Classifications.set(r.reddit_id, r);
+        }
+      } else {
+        // V1: Original classification pipeline
+        const results = await classifyPostsRealtime(
+          classificationInputs,
           productName,
           productDescription,
           competitors
         );
 
-        for (const r of sonnetResults) {
+        for (const r of results) {
           aiClassifications.set(r.reddit_id, r);
         }
+
+        // 4. Sonnet fallback for ambiguous results (medium bin)
+        const ambiguous = results.filter((r) => r.score_bin === 'medium');
+        if (ambiguous.length > 0) {
+          const ambiguousInputs = classificationInputs.filter((i) =>
+            ambiguous.some((a) => a.reddit_id === i.reddit_id)
+          );
+
+          const sonnetResults = await reclassifyWithSonnet(
+            ambiguousInputs,
+            productName,
+            productDescription,
+            competitors
+          );
+
+          for (const r of sonnetResults) {
+            aiClassifications.set(r.reddit_id, r);
+          }
+        }
       }
+    } catch (aiError) {
+      // AI classification failed (e.g. out of credits) — continue with Tier 1 scores only
+      console.warn('[Detector] AI classification failed, using Tier 1 scores only:', (aiError as Error).message);
     }
   }
 


### PR DESCRIPTION
## Summary
- **Fix scan returning 0 signals**: Removed queue-based scanning for manual "Scan Now" which was silently skipping detection. Now always runs inline for immediate results.
- **Fix keyword lookup**: Reads keywords from `outreach_keywords` table (where the wizard saves them) instead of only `outreach_configs.keywords`. Falls back to product name as a phrase instead of noisy single words.
- **Add subreddit browsing fallback**: When keyword search returns 0 posts, falls back to browsing recent posts from monitored subreddits directly via multi-sub request.
- **Graceful AI failure handling**: Catches Anthropic API errors (e.g. out of credits) and saves Tier 1 regex-scored signals instead of crashing.
- **Signals UI improvements**: Clickable Hot/Warm/Unseen analytics filters, compact subreddit ranking cards with rank badges, prominent subreddit badges on signal cards, tier-colored card borders (red for hot, amber for warm).

## Test plan
- [ ] Click "Scan Now" — should find signals within a few seconds (not 0)
- [ ] Click "Warm Leads" card — filters to warm leads only
- [ ] Click "Hot Leads" card — filters to hot leads only
- [ ] Click "Unseen" card — filters to unseen signals
- [ ] Click "Total Signals" card — clears filter, shows all
- [ ] Verify subreddit ranking cards show correct counts and percentages
- [ ] Verify signal cards show subreddit badge prominently above title
- [ ] Verify warm lead cards have amber border, hot leads have red border

🤖 Generated with [Claude Code](https://claude.com/claude-code)