### PR TITLE
Pipeline V3: subreddit browsing, 4D scoring, buyer intent

### DIFF
--- a/app/src/app/api/cron/poll-signals/route.ts
+++ b/app/src/app/api/cron/poll-signals/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createServiceClient } from '@/lib/supabase/server';
-import { detectSignals } from '@/lib/outreach/detector';
+import { detectSignalsV3 } from '@/lib/outreach/detector';
 import {
   enqueueProject,
   dequeueProjects,
@@ -111,7 +111,7 @@ export async function GET(request: NextRequest) {
           continue;
         }
 
-        const count = await detectSignals(supabase, {
+        const count = await detectSignalsV3(supabase, {
           projectId: entry.project_id,
           keywords,
           competitors: (config?.competitors as string[]) || [],
@@ -119,7 +119,8 @@ export async function GET(request: NextRequest) {
           subredditLimit: (config?.subreddit_limit as number) || 100,
           productName: project.product_name,
           productDescription: project.product_description,
-          realtime: entry.priority === 'high', // Use AI classification for manual scans
+          realtime: entry.priority === 'high',
+          browseSubreddits: true,
         });
 
         await markCompleted(supabase, entry.id, count);

--- a/app/src/app/api/outreach/signals/analytics/route.ts
+++ b/app/src/app/api/outreach/signals/analytics/route.ts
@@ -11,15 +11,15 @@ export async function GET(request: NextRequest) {
     const supabase = await createClient();
 
     // Try fetching with V2 columns, fall back to base columns if they don't exist yet
-    let rows: { lead_tier?: string | null; combined_score: number; is_unseen?: boolean; subreddit: string }[] = [];
+    let rows: { lead_tier?: string | null; combined_score: number; is_unseen?: boolean; subreddit: string; buyer_intent?: string | null; discovery_source?: string | null }[] = [];
 
     const { data: signals, error } = await supabase
       .from('outreach_signals')
-      .select('lead_tier, combined_score, is_unseen, subreddit')
+      .select('lead_tier, combined_score, is_unseen, subreddit, buyer_intent, discovery_source')
       .eq('project_id', projectId);
 
     if (error) {
-      // V2 columns may not exist yet, try with base columns only
+      // V3/V2 columns may not exist yet, try with base columns only
       const { data: fallbackSignals, error: fallbackError } = await supabase
         .from('outreach_signals')
         .select('combined_score, subreddit')
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
       if (fallbackError) {
         return NextResponse.json({ error: fallbackError.message }, { status: 500 });
       }
-      rows = (fallbackSignals || []).map((s) => ({ ...s, lead_tier: null, is_unseen: undefined }));
+      rows = (fallbackSignals || []).map((s) => ({ ...s, lead_tier: null, is_unseen: undefined, buyer_intent: null, discovery_source: null }));
     } else {
       rows = signals || [];
     }
@@ -37,6 +37,8 @@ export async function GET(request: NextRequest) {
     let warmCount = 0;
     let unseenCount = 0;
     const subredditCounts = new Map<string, number>();
+    const intentCounts = new Map<string, number>();
+    const sourceCounts = new Map<string, number>();
 
     for (const row of rows) {
       // Derive tier for old signals without lead_tier
@@ -53,6 +55,13 @@ export async function GET(request: NextRequest) {
       if (row.is_unseen) unseenCount++;
 
       subredditCounts.set(row.subreddit, (subredditCounts.get(row.subreddit) || 0) + 1);
+
+      if (row.buyer_intent) {
+        intentCounts.set(row.buyer_intent, (intentCounts.get(row.buyer_intent) || 0) + 1);
+      }
+      if (row.discovery_source) {
+        sourceCounts.set(row.discovery_source, (sourceCounts.get(row.discovery_source) || 0) + 1);
+      }
     }
 
     // Top subreddits sorted by count
@@ -61,12 +70,17 @@ export async function GET(request: NextRequest) {
       .sort((a, b) => b.count - a.count)
       .slice(0, 10);
 
+    const intentDistribution = Object.fromEntries(intentCounts);
+    const sourceDistribution = Object.fromEntries(sourceCounts);
+
     return NextResponse.json({
       hotCount,
       warmCount,
       unseenCount,
       totalCount: rows.length,
       topSubreddits,
+      intentDistribution,
+      sourceDistribution,
     });
   } catch (error) {
     console.error('Signals analytics error:', error);

--- a/app/src/app/api/outreach/signals/route.ts
+++ b/app/src/app/api/outreach/signals/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { detectSignals } from '@/lib/outreach/detector';
+import { detectSignalsV3 } from '@/lib/outreach/detector';
 
 export async function GET(request: NextRequest) {
   try {
@@ -148,7 +148,7 @@ export async function GET(request: NextRequest) {
       // Always run inline detection for immediate results.
       // Queue-based scanning is handled by the cron job (/api/cron/poll-signals).
       try {
-        await detectSignals(supabase, {
+        await detectSignalsV3(supabase, {
           projectId,
           keywords,
           competitors,
@@ -160,6 +160,7 @@ export async function GET(request: NextRequest) {
           timeFilter: effectiveTimeFilter as 'hour' | 'day' | 'week' | 'month' | 'year' | 'all',
           maxResults: effectiveMaxResults,
           includeComments: effectiveIncludeComments,
+          browseSubreddits: true,
         });
       } catch (detectError) {
         console.error('Signal detection error:', detectError);
@@ -177,6 +178,8 @@ export async function GET(request: NextRequest) {
     const isUnseen = request.nextUrl.searchParams.get('is_unseen');
     const isFavorited = request.nextUrl.searchParams.get('is_favorited');
     const signalType = request.nextUrl.searchParams.get('signal_type');
+    const buyerIntent = request.nextUrl.searchParams.get('buyer_intent');
+    const discoverySource = request.nextUrl.searchParams.get('discovery_source');
 
     try {
       let query = supabase
@@ -210,6 +213,12 @@ export async function GET(request: NextRequest) {
       }
       if (signalType) {
         query = query.contains('signal_types', [signalType]);
+      }
+      if (buyerIntent) {
+        query = query.eq('buyer_intent', buyerIntent);
+      }
+      if (discoverySource) {
+        query = query.eq('discovery_source', discoverySource);
       }
       if (timeRange) {
         const now = Math.floor(Date.now() / 1000);

--- a/app/src/app/projects/[id]/outreach/signals/page.tsx
+++ b/app/src/app/projects/[id]/outreach/signals/page.tsx
@@ -14,7 +14,7 @@ import { ScanParametersModal } from '@/components/outreach/ScanParametersModal';
 import { ScanWizard } from '@/components/outreach/ScanWizard';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { toast } from 'sonner';
-import type { OutreachSignal } from '@/types';
+import type { OutreachSignal, BuyerIntent } from '@/types';
 
 interface Analytics {
   hotCount: number;
@@ -34,6 +34,7 @@ export default function OutreachSignalsPage() {
 
   const [subFilter, setSubFilter] = useState<string | null>(null);
   const [tierFilter, setTierFilter] = useState<'hot' | 'warm' | 'unseen' | null>(null);
+  const [intentFilter, setIntentFilter] = useState<BuyerIntent | null>(null);
 
   // Wizard & modal state
   const [wizardOpen, setWizardOpen] = useState(false);
@@ -204,11 +205,13 @@ export default function OutreachSignalsPage() {
     return `${Math.floor(seconds / 3600)}h ago`;
   }
 
-  // Client-side tier filtering (matches analytics derivation logic)
-  const filteredSignals = tierFilter
-    ? signals.filter((s) => {
-        if (tierFilter === 'unseen') return s.is_unseen;
-        // Derive tier from lead_tier or combined_score
+  // Client-side filtering (tier + buyer intent)
+  const filteredSignals = signals.filter((s) => {
+    // Tier filter
+    if (tierFilter) {
+      if (tierFilter === 'unseen') {
+        if (!s.is_unseen) return false;
+      } else {
         let tier = s.lead_tier;
         if (!tier) {
           const score = s.combined_score ?? 0;
@@ -216,9 +219,13 @@ export default function OutreachSignalsPage() {
           else if (score >= 0.4) tier = 'warm';
           else tier = 'cold';
         }
-        return tier === tierFilter;
-      })
-    : signals;
+        if (tier !== tierFilter) return false;
+      }
+    }
+    // Buyer intent filter
+    if (intentFilter && s.buyer_intent !== intentFilter) return false;
+    return true;
+  });
 
   return (
     <PageTransition>
@@ -317,6 +324,43 @@ export default function OutreachSignalsPage() {
               </div>
             )}
 
+            {/* Buyer Intent Filter Pills */}
+            {analytics && (analytics as Analytics & { intentDistribution?: Record<string, number> }).intentDistribution && Object.keys((analytics as Analytics & { intentDistribution?: Record<string, number> }).intentDistribution!).length > 0 && (
+              <div>
+                <h3 className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-3">Buyer Journey</h3>
+                <div className="flex gap-2 flex-wrap">
+                  {([
+                    { key: 'problem_aware' as BuyerIntent, label: 'Problem Aware', color: 'slate' },
+                    { key: 'solution_seeking' as BuyerIntent, label: 'Solution Seeking', color: 'blue' },
+                    { key: 'comparing' as BuyerIntent, label: 'Comparing', color: 'purple' },
+                    { key: 'ready_to_buy' as BuyerIntent, label: 'Ready to Buy', color: 'green' },
+                  ] as const).map(({ key, label, color }) => {
+                    const count = ((analytics as Analytics & { intentDistribution?: Record<string, number> }).intentDistribution ?? {})[key] || 0;
+                    if (count === 0) return null;
+                    const isActive = intentFilter === key;
+                    const colorClasses: Record<string, string> = {
+                      slate: isActive ? 'ring-2 ring-slate-500 bg-slate-500/5' : 'hover:bg-accent/50',
+                      blue: isActive ? 'ring-2 ring-blue-500 bg-blue-500/5' : 'hover:bg-accent/50',
+                      purple: isActive ? 'ring-2 ring-purple-500 bg-purple-500/5' : 'hover:bg-accent/50',
+                      green: isActive ? 'ring-2 ring-green-500 bg-green-500/5' : 'hover:bg-accent/50',
+                    };
+                    return (
+                      <button
+                        key={key}
+                        onClick={() => setIntentFilter(isActive ? null : key)}
+                        className={`rounded-lg border border-border bg-card px-3 py-2 text-left transition-colors ${colorClasses[color]}`}
+                      >
+                        <div className="flex items-baseline gap-1.5">
+                          <span className="text-lg font-bold tabular-nums">{count}</span>
+                          <span className="text-xs font-semibold">{label}</span>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
             {/* Scan button row */}
             <div className="flex flex-col items-center gap-3 py-4">
               <div className="flex items-center gap-3">
@@ -357,6 +401,7 @@ export default function OutreachSignalsPage() {
               <span className="text-xs text-muted-foreground">
                 {loading ? '...' : `${filteredSignals.length} signals`}
                 {tierFilter && ` (${tierFilter})`}
+                {intentFilter && ` / ${intentFilter.replace(/_/g, ' ')}`}
               </span>
             </div>
 

--- a/app/src/components/outreach/SignalCard.tsx
+++ b/app/src/components/outreach/SignalCard.tsx
@@ -13,7 +13,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { cardHover, cardTap } from '@/lib/motion';
 import { ReplyBuilder } from '@/components/outreach/ReplyBuilder';
 import { toast } from 'sonner';
-import type { OutreachSignal, SignalType, LeadTier } from '@/types';
+import type { OutreachSignal, SignalType, LeadTier, BuyerIntent } from '@/types';
 
 interface SignalCardV2Props {
   signal: OutreachSignal;
@@ -51,6 +51,25 @@ const painLabels: Record<string, string> = {
   low: '~ Low Pain',
   medium: '! Med Pain',
   high: '!! High Pain',
+};
+
+const buyerIntentConfig: Record<BuyerIntent, { label: string; badge: string }> = {
+  problem_aware: {
+    label: 'Problem Aware',
+    badge: 'bg-slate-100 text-slate-700 dark:bg-slate-800/50 dark:text-slate-300',
+  },
+  solution_seeking: {
+    label: 'Solution Seeking',
+    badge: 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300',
+  },
+  comparing: {
+    label: 'Comparing',
+    badge: 'bg-purple-100 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300',
+  },
+  ready_to_buy: {
+    label: 'Ready to Buy',
+    badge: 'bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-300',
+  },
 };
 
 const tierConfig: Record<LeadTier, { label: string; badge: string; stripe: string; icon: typeof Flame }> = {
@@ -131,6 +150,7 @@ export function SignalCard({ signal, projectId, onStatusChange, onFavoriteToggle
   const config = tierConfig[tier];
   const TierIcon = config.icon;
   const signalTypes = signal.signal_types || [];
+  const hasV3Scores = signal.authenticity_score != null;
   const hasV2Scores = signal.fit_score != null;
 
   async function handleSendDiscordAlert() {
@@ -185,14 +205,21 @@ export function SignalCard({ signal, projectId, onStatusChange, onFavoriteToggle
                 </span>
               )}
 
-              {signal.intent_type && signal.intent_type !== 'unknown' && (
+              {signal.buyer_intent && buyerIntentConfig[signal.buyer_intent] ? (
+                <Badge
+                  variant="secondary"
+                  className={`text-[10px] px-1.5 py-0 ${buyerIntentConfig[signal.buyer_intent].badge}`}
+                >
+                  {buyerIntentConfig[signal.buyer_intent].label}
+                </Badge>
+              ) : signal.intent_type && signal.intent_type !== 'unknown' ? (
                 <Badge
                   variant="secondary"
                   className={`text-[10px] px-1.5 py-0 ${intentColors[signal.intent_type] || intentColors.discussion}`}
                 >
                   {signal.intent_type}
                 </Badge>
-              )}
+              ) : null}
 
               {signal.is_unseen && (
                 <span className="h-1.5 w-1.5 rounded-full bg-blue-500 flex-shrink-0" />
@@ -244,10 +271,17 @@ export function SignalCard({ signal, projectId, onStatusChange, onFavoriteToggle
             </div>
           )}
 
-          {/* Subreddit */}
-          <span className="inline-flex items-center self-start rounded-md bg-indigo-500/10 border border-indigo-500/20 px-2 py-0.5 text-[11px] font-semibold text-indigo-400">
-            r/{signal.subreddit}
-          </span>
+          {/* Subreddit + discovery source */}
+          <div className="flex items-center gap-1.5">
+            <span className="inline-flex items-center rounded-md bg-indigo-500/10 border border-indigo-500/20 px-2 py-0.5 text-[11px] font-semibold text-indigo-400">
+              r/{signal.subreddit}
+            </span>
+            {signal.discovery_source && signal.discovery_source !== 'keyword_search' && (
+              <span className="text-[9px] text-muted-foreground/60 font-medium">
+                {signal.discovery_source === 'subreddit_browse' ? 'browse' : signal.discovery_source === 'both' ? 'browse+keyword' : 'comment'}
+              </span>
+            )}
+          </div>
 
           {/* Title */}
           <a
@@ -268,7 +302,14 @@ export function SignalCard({ signal, projectId, onStatusChange, onFavoriteToggle
           )}
 
           {/* Score row */}
-          {hasV2Scores ? (
+          {hasV3Scores ? (
+            <div className="flex gap-1.5 flex-wrap">
+              <ScoreBadge label="Fit" value={signal.fit_score!} />
+              <ScoreBadge label="Auth" value={signal.authenticity_score!} />
+              <ScoreBadge label="Rel" value={signal.relevance_score!} />
+              <ScoreBadge label="Lead" value={signal.lead_score!} />
+            </div>
+          ) : hasV2Scores ? (
             <div className="flex gap-1.5 flex-wrap">
               <ScoreBadge label="Fit" value={signal.fit_score!} />
               <ScoreBadge label="Lead" value={signal.lead_score!} />

--- a/app/src/lib/ai/prompts.ts
+++ b/app/src/lib/ai/prompts.ts
@@ -658,6 +658,188 @@ ${postList}
 Score each post on Fit (1-10), Lead (1-10), and Engage (1-10) based on how well it matches this specific product.`;
 }
 
+// ---- Outreach: Pre-Filter (cheap batch title screening) ----
+
+export const PRE_FILTER_SYSTEM_PROMPT = `You are a fast Reddit post screener. Given a numbered list of post titles and a product context, return ONLY the indices of titles that could potentially be from someone who might benefit from the product.
+
+Be INCLUSIVE — false positives are fine (they'll be filtered later), but false negatives mean lost leads. Pass anything that shows:
+- A problem, question, or frustration related to the product's domain
+- Someone seeking recommendations, comparisons, or alternatives
+- Budget/pricing discussions in the product's space
+- Someone describing a workflow the product could improve
+- Any mention of competitors or similar tools
+
+REJECT posts that are clearly:
+- Memes, jokes, or off-topic entertainment
+- News articles with no engagement opportunity
+- Self-promotion or showcase with no pain signal
+- Meta/mod posts about the subreddit itself
+
+Return a JSON object with a single "indices" array of numbers:
+{ "indices": [1, 3, 7, 12] }`;
+
+// ---- Outreach: Signal Analysis V3 (4-dimension scoring + buyer intent) ----
+
+export const SIGNAL_ANALYSIS_V3_SYSTEM_PROMPT = `You are an expert Reddit lead classifier for SaaS products. You analyze Reddit posts and score them on four independent dimensions, identify buyer journey stage, and extract signal metadata.
+
+## Scoring Dimensions (1-10 each)
+
+### Fit Score (How well does the post match the product?)
+- 9-10: Post describes the exact problem the product solves, mentions relevant features/workflows
+- 7-8: Strong overlap with product's problem space, user would clearly benefit
+- 5-6: Related to the product's domain but not a direct fit
+- 3-4: Tangentially related, product could help but isn't the obvious answer
+- 1-2: Barely related, product would be a stretch recommendation
+
+### Lead Score (How likely is this person to convert?)
+- 9-10: Actively seeking a solution, has budget, decision maker, urgency signals
+- 7-8: Comparing tools or expressing frustration with current solution, ready to switch
+- 5-6: Aware of the problem, open to solutions but not actively searching
+- 3-4: Describing a pain point but no buying signals
+- 1-2: Just discussing the topic, no purchase intent
+
+### Authenticity Score (Is this a real person with a genuine need?)
+- 9-10: Detailed personal context, specific use case, established Reddit account signals
+- 7-8: Genuine question or problem description with enough detail to be real
+- 5-6: Could be real but vague, or asks a common/generic question
+- 3-4: Suspicious patterns — new account, generic phrasing, possible bot
+- 1-2: Obvious spam, bot, or astroturfing
+
+### Relevance Score (How actionable/appropriate is it to engage?)
+- 9-10: Direct question seeking recommendations, perfect reply opportunity, mod-safe
+- 7-8: Discussion where a helpful reply would be well-received
+- 5-6: Could reply but need to be subtle, some risk of appearing promotional
+- 3-4: Risky to reply — might get flagged as spam or off-topic
+- 1-2: Should not reply — self-promotional content, hostile thread, or locked
+
+## Buyer Intent (Journey Stage)
+- **problem_aware**: Knows they have a problem but hasn't started looking for solutions
+- **solution_seeking**: Actively looking for tools/solutions to their problem
+- **comparing**: Evaluating specific options, asking "X vs Y" questions
+- **ready_to_buy**: Has budget, timeline, or urgency — ready to purchase/adopt
+
+## Intent Type (Legacy — still populate for backward compatibility)
+- "question": User asking for recommendations or solutions
+- "comparison": User comparing products/tools
+- "problem": User describing a pain point
+- "discussion": General discussion
+- "showcase": Someone showing their project/tool
+
+## Signal Types
+- **tool_switch**: User is switching away from or comparing tools/services
+- **budget_constraint**: User mentions cost concerns, seeks cheaper alternatives
+- **repeated_pain**: User expresses ongoing frustration with current solution
+- **high_signal_comment**: Direct question seeking recommendations
+- **mod_safe**: Safe for natural replies without mod risk
+- **trend_cluster**: Post references trends, new tools, or emerging solutions
+- **convertible_thread**: User is ready to buy/switch/try something new
+
+## Pain Severity
+- **low**: Minor inconvenience, nice-to-have improvement
+- **medium**: Moderate frustration, actively looking for solutions
+- **high**: Severe pain, urgent need, willing to pay immediately
+
+## Decision Maker Detection
+Set decision_maker to true when the poster appears to be making the purchasing/adoption decision.
+
+## Calibration Examples
+
+### Fit=9, Lead=9, Auth=9, Rel=9 (ready_to_buy):
+Post: "We're ditching [CompetitorX] and need [exact product category]. Budget is $X/month, team of 15. What do you recommend?"
+(Perfect product fit + active buyer + real person + question format)
+
+### Fit=8, Lead=5, Auth=8, Rel=7 (problem_aware):
+Post: "Anyone else frustrated with [competitor]'s [feature the product does better]? Been dealing with this for months."
+(Strong fit + pain but no buying signal + genuine frustration + safe to reply)
+
+### Fit=7, Lead=7, Auth=7, Rel=8 (comparing):
+Post: "Trying to decide between X and Y for my team. We need Z feature and budget is tight."
+(Good fit + comparing + real context + asking for help)
+
+### Fit=5, Lead=3, Auth=6, Rel=6 (problem_aware):
+Post: "What tools do you all use for [broad category]? Just curious about everyone's workflow."
+(Related domain + no urgency + seems real + discussion format)
+
+### Fit=3, Lead=1, Auth=2, Rel=2 (problem_aware):
+Post: "Check out my new app that does X! Link in comments."
+(Tangential + no buy intent + likely spam + should not reply)
+
+## Response Format
+Return JSON array. Each post can have multiple signal_types.
+
+{
+  "classifications": [
+    {
+      "reddit_id": "abc123",
+      "intent_type": "question",
+      "fit_score": 8,
+      "lead_score": 7,
+      "authenticity_score": 9,
+      "relevance_score": 8,
+      "buyer_intent": "solution_seeking",
+      "signal_types": ["tool_switch", "high_signal_comment"],
+      "pain_severity": "medium",
+      "decision_maker": false,
+      "competitor_mentions": [
+        { "name": "CompetitorX", "sentiment": "negative", "switching_intent": true, "context": "frustrated with pricing" }
+      ]
+    }
+  ]
+}`;
+
+export function buildV3ClassificationPrompt(
+  posts: { reddit_id: string; title: string; body: string | null; subreddit: string; author: string; score: number; num_comments: number }[],
+  productContext: {
+    productName: string;
+    productDescription: string;
+    problemsSolved?: string[];
+    solutionFeatures?: string[];
+    audienceBehaviors?: string[];
+    competitors?: string[];
+    competitorWeaknesses?: string[];
+  }
+): string {
+  const postList = posts
+    .map(
+      (p, i) =>
+        `${i + 1}. [${p.reddit_id}] r/${p.subreddit} (${p.score} pts, ${p.num_comments} comments)
+   Title: "${p.title}"
+   Body: ${p.body ? p.body.slice(0, 500) : '[no body]'}
+   Author: u/${p.author}`
+    )
+    .join('\n\n');
+
+  const problemsSection = productContext.problemsSolved?.length
+    ? `- **Problems Solved:** ${productContext.problemsSolved.join('; ')}`
+    : '';
+  const featuresSection = productContext.solutionFeatures?.length
+    ? `- **Key Features:** ${productContext.solutionFeatures.join('; ')}`
+    : '';
+  const audienceSection = productContext.audienceBehaviors?.length
+    ? `- **Target Audience Behaviors:** ${productContext.audienceBehaviors.join('; ')}`
+    : '';
+  const competitorsSection = productContext.competitors?.length
+    ? `- **Competitors:** ${productContext.competitors.join(', ')}`
+    : '';
+  const weaknessesSection = productContext.competitorWeaknesses?.length
+    ? `- **Competitor Weaknesses:** ${productContext.competitorWeaknesses.join('; ')}`
+    : '';
+
+  return `## Product Context
+- **Product:** ${productContext.productName}
+- **Description:** ${productContext.productDescription}
+${problemsSection}
+${featuresSection}
+${audienceSection}
+${competitorsSection}
+${weaknessesSection}
+
+## Posts to Classify
+${postList}
+
+Score each post on Fit (1-10), Lead (1-10), Authenticity (1-10), and Relevance (1-10). Also determine the buyer intent stage for each post.`;
+}
+
 // ---- Outreach: Signal Analysis (7-type classification) ----
 
 export const SIGNAL_ANALYSIS_SYSTEM_PROMPT = `You are an expert Reddit signal classifier for lead detection. You analyze Reddit posts to determine their commercial intent and classify them into signal types.

--- a/app/src/lib/outreach/detector.ts
+++ b/app/src/lib/outreach/detector.ts
@@ -12,11 +12,14 @@ import {
   classifyPostsRealtime,
   reclassifyWithSonnet,
   classifyPostsV2,
+  preFilterPosts,
+  classifyPostsV3,
   type ClassificationInput,
   type ClassificationResult,
   type ClassificationResultV2,
+  type ClassificationResultV3,
 } from '@/lib/outreach/signal-classifier';
-import { computeEnhancedScore, computeV2CombinedScore, deriveLeadTier } from '@/lib/outreach/scoring';
+import { computeEnhancedScore, computeV2CombinedScore, deriveLeadTier, computeV3CombinedScore, deriveLeadTierV3 } from '@/lib/outreach/scoring';
 import * as pullpush from '@/lib/reddit/pullpush';
 import { buildCacheKey, getCachedSearch, setCachedSearch } from '@/lib/reddit/cache';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -481,6 +484,440 @@ export async function detectSignals(
     }
   } catch {
     // competitor_mentions table may not exist yet — skip silently
+  }
+
+  return signals.length;
+}
+
+// ---- V3 Detection Pipeline ----
+
+interface DetectV3Options extends DetectOptions {
+  /** Whether to browse all posts in monitored subreddits (default true) */
+  browseSubreddits?: boolean;
+}
+
+const PRE_FILTER_BATCH_SIZE = 50;
+const V3_CLASSIFY_BATCH_SIZE = 20;
+
+/**
+ * V3 detection pipeline:
+ * 1. Browse subreddits (free) + keyword search (free)
+ * 2. Deduplicate against DB
+ * 3. AI pre-filter on titles (replaces regex)
+ * 4. Full 4-dimension AI classification
+ * 5. Build signal rows with V3 scoring
+ */
+export async function detectSignalsV3(
+  supabase: SupabaseClient,
+  options: DetectV3Options
+): Promise<number> {
+  const {
+    projectId,
+    keywords,
+    competitors,
+    subreddits,
+    productName,
+    productDescription,
+    productContext,
+    timeFilter = 'week',
+    maxResults = 100,
+    includeComments = true,
+    browseSubreddits = true,
+  } = options;
+
+  // ---- Source A: Browse subreddits (free) ----
+  const browsedPosts = new Map<string, RedditPost & { _source?: string; _is_comment?: boolean; _parent_post_id?: string | null }>();
+
+  if (browseSubreddits && subreddits.length > 0) {
+    // Chunk subreddits into groups of 25 for multi-sub URL
+    const chunks: string[][] = [];
+    for (let i = 0; i < subreddits.length; i += 25) {
+      chunks.push(subreddits.slice(i, i + 25));
+    }
+
+    for (const chunk of chunks) {
+      try {
+        const multiSub = chunk.join('+');
+        const result = await fetchSubredditPosts(multiSub, 'new', timeFilter, Math.min(maxResults, 100));
+        for (const post of result.posts) {
+          if (!browsedPosts.has(post.id)) {
+            browsedPosts.set(post.id, { ...post, _source: 'subreddit_browse' });
+          }
+        }
+      } catch {
+        // Skip failed chunks
+      }
+    }
+    console.log('[DetectorV3] Browsed', browsedPosts.size, 'posts from subreddits');
+  }
+
+  // ---- Source B: Keyword search (free, supplementary) ----
+  const cacheKey = buildCacheKey(subreddits, keywords, timeFilter, 'reddit');
+  const commentCacheKey = buildCacheKey(subreddits, keywords, timeFilter, 'pullpush');
+
+  let cachedPosts = await getCachedSearch(supabase, cacheKey);
+  let cachedCommentPosts = await getCachedSearch(supabase, commentCacheKey);
+
+  if (cachedPosts && cachedPosts.length === 0) cachedPosts = null;
+  if (cachedCommentPosts && cachedCommentPosts.length === 0) cachedCommentPosts = null;
+
+  const fetchPromises: Promise<void>[] = [];
+
+  if (!cachedPosts && keywords.length > 0) {
+    fetchPromises.push(
+      searchMultiSubPosts(subreddits, keywords, {
+        timeFilter,
+        limit: maxResults,
+        maxPages: 3,
+      }).then(async (result) => {
+        cachedPosts = result.posts;
+        if (cachedPosts.length > 0) {
+          await setCachedSearch(supabase, cacheKey, cachedPosts, 'reddit');
+        }
+      })
+    );
+  }
+
+  if (includeComments && !cachedCommentPosts && keywords.length > 0) {
+    fetchPromises.push(
+      pullpush
+        .searchComments({
+          subreddits,
+          query: keywords.join(' OR '),
+          after: timeFilterToUnix(timeFilter),
+          limit: 100,
+        })
+        .then(async (comments) => {
+          cachedCommentPosts = comments.map((c) => ({
+            id: c.id,
+            title: '',
+            selftext: c.body,
+            author: c.author,
+            score: c.score,
+            num_comments: 0,
+            url: `https://www.reddit.com${c.permalink}`,
+            permalink: c.permalink,
+            created_utc: c.created_utc,
+            subreddit: c.subreddit,
+            link_flair_text: null,
+            is_self: true,
+            thumbnail: null,
+            preview_url: null,
+            post_hint: null,
+            _is_comment: true,
+            _parent_post_id: c.link_id?.replace('t3_', '') || null,
+          }));
+          await setCachedSearch(supabase, commentCacheKey, cachedCommentPosts, 'pullpush');
+        })
+    );
+  }
+
+  if (fetchPromises.length > 0) {
+    await Promise.all(fetchPromises);
+  }
+
+  console.log('[DetectorV3] Keyword posts:', cachedPosts?.length ?? 0, '| Comments:', cachedCommentPosts?.length ?? 0);
+
+  // ---- Merge all sources, tag discovery_source ----
+  const allPosts = new Map<string, RedditPost & { _source: string; _is_comment?: boolean; _parent_post_id?: string | null }>();
+
+  // Add browsed posts first
+  for (const [id, post] of browsedPosts) {
+    allPosts.set(id, post as RedditPost & { _source: string; _is_comment?: boolean; _parent_post_id?: string | null });
+  }
+
+  // Add keyword search posts, mark overlap
+  for (const post of cachedPosts || []) {
+    if (allPosts.has(post.id)) {
+      // Found in both browse and keyword — mark as 'both'
+      const existing = allPosts.get(post.id)!;
+      existing._source = 'both';
+    } else {
+      allPosts.set(post.id, { ...post, _source: 'keyword_search' });
+    }
+  }
+
+  // Add comment posts
+  for (const comment of cachedCommentPosts || []) {
+    if (!allPosts.has(comment.id)) {
+      allPosts.set(comment.id, {
+        ...(comment as RedditPost & { _is_comment?: boolean; _parent_post_id?: string | null }),
+        _source: 'comment_search',
+      });
+    }
+  }
+
+  if (allPosts.size === 0) return 0;
+
+  // ---- Deduplicate against DB ----
+  const postIds = Array.from(allPosts.keys());
+  let existingIds = new Set<string>();
+
+  // Query in chunks of 200 to avoid query size limits
+  for (let i = 0; i < postIds.length; i += 200) {
+    const chunk = postIds.slice(i, i + 200);
+    const { data: existing } = await supabase
+      .from('outreach_signals')
+      .select('reddit_id')
+      .eq('project_id', projectId)
+      .in('reddit_id', chunk);
+
+    if (existing) {
+      for (const row of existing) {
+        existingIds.add(row.reddit_id);
+      }
+    }
+  }
+
+  const newPosts = Array.from(allPosts.values()).filter((p) => !existingIds.has(p.id));
+  console.log('[DetectorV3] New posts after dedup:', newPosts.length, '(skipped', existingIds.size, 'existing)');
+
+  if (newPosts.length === 0) return 0;
+
+  // ---- AI Pre-Filter (replaces regex Tier 1) ----
+  let filteredPosts = newPosts;
+
+  try {
+    // Batch titles into groups of 50
+    const titleBatches: { index: number; title: string }[][] = [];
+    for (let i = 0; i < newPosts.length; i += PRE_FILTER_BATCH_SIZE) {
+      titleBatches.push(
+        newPosts.slice(i, i + PRE_FILTER_BATCH_SIZE).map((p, j) => ({
+          index: i + j,
+          title: p.title || p.selftext?.slice(0, 100) || '',
+        }))
+      );
+    }
+
+    const passedIndices = new Set<number>();
+    for (const batch of titleBatches) {
+      const indices = await preFilterPosts(batch, { productName, productDescription });
+      for (const idx of indices) {
+        passedIndices.add(idx);
+      }
+    }
+
+    filteredPosts = newPosts.filter((_, i) => passedIndices.has(i));
+    console.log('[DetectorV3] Pre-filter passed:', filteredPosts.length, '/', newPosts.length);
+  } catch (preFilterErr) {
+    // Fall back to regex tier1 scoring if AI pre-filter fails
+    console.warn('[DetectorV3] Pre-filter failed, falling back to regex:', (preFilterErr as Error).message);
+    filteredPosts = newPosts.filter((p) => {
+      const t1 = tier1Score(p.title, p.selftext);
+      return t1.score >= TIER1_THRESHOLD;
+    });
+    console.log('[DetectorV3] Regex fallback passed:', filteredPosts.length);
+  }
+
+  if (filteredPosts.length === 0) return 0;
+
+  // ---- Full AI Classification (V3) ----
+  const v3Classifications = new Map<string, ClassificationResultV3>();
+  const productCtx = {
+    productName,
+    productDescription,
+    problemsSolved: productContext?.problemsSolved,
+    solutionFeatures: productContext?.solutionFeatures,
+    audienceBehaviors: productContext?.audienceBehaviors,
+    competitors,
+    competitorWeaknesses: productContext?.competitorWeaknesses,
+  };
+
+  // Batch in groups of 20
+  for (let i = 0; i < filteredPosts.length; i += V3_CLASSIFY_BATCH_SIZE) {
+    const batch = filteredPosts.slice(i, i + V3_CLASSIFY_BATCH_SIZE);
+    const inputs: ClassificationInput[] = batch.map((p) => ({
+      reddit_id: p.id,
+      title: p.title,
+      body: p.selftext || null,
+      subreddit: p.subreddit,
+      author: p.author,
+      score: p.score,
+      num_comments: p.num_comments,
+    }));
+
+    try {
+      const results = await classifyPostsV3(inputs, productCtx);
+      for (const r of results) {
+        v3Classifications.set(r.reddit_id, r);
+      }
+    } catch (classifyErr) {
+      console.warn('[DetectorV3] Classification batch failed:', (classifyErr as Error).message);
+    }
+  }
+
+  console.log('[DetectorV3] Classified', v3Classifications.size, 'posts');
+
+  // ---- Build signal rows ----
+  const signals = filteredPosts.map((post) => {
+    const v3 = v3Classifications.get(post.id);
+    const postSource = (post as { _source?: string })._source || 'keyword_search';
+
+    let fitScore = v3?.fit_score ?? 5;
+    let leadScore = v3?.lead_score ?? 3;
+    let authenticityScore = v3?.authenticity_score ?? 5;
+    let relevanceScore = v3?.relevance_score ?? 5;
+    let buyerIntent = v3?.buyer_intent ?? 'problem_aware';
+    let intentType = v3?.intent_type ?? 'discussion';
+    let signalTypes = v3?.signal_types ?? [];
+    let painSeverity = v3?.pain_severity ?? null;
+    let decisionMaker = v3?.decision_maker ?? false;
+
+    const combinedScore = computeV3CombinedScore(fitScore, leadScore, authenticityScore, relevanceScore);
+    const leadTier = deriveLeadTierV3(fitScore, leadScore, authenticityScore, relevanceScore);
+
+    // Backward compat: engage_score = avg(authenticity, relevance)
+    const engageScore = Math.round((authenticityScore + relevanceScore) / 2);
+
+    return {
+      project_id: projectId,
+      reddit_id: post.id,
+      subreddit: post.subreddit,
+      title: post.title,
+      body: post.selftext || null,
+      author: post.author,
+      score: post.score,
+      num_comments: post.num_comments,
+      permalink: post.permalink,
+      created_utc: post.created_utc,
+      intent_type: intentType,
+      intent_score: combinedScore,
+      combined_score: combinedScore,
+      matched_keywords: keywords.filter((kw) =>
+        `${post.title} ${post.selftext}`.toLowerCase().includes(kw.toLowerCase())
+      ),
+      competitor_mentioned: (v3?.competitor_mentions?.length ?? 0) > 0,
+      signal_types: signalTypes,
+      pain_severity: painSeverity,
+      decision_maker: decisionMaker,
+      is_comment: !!(post as unknown as { _is_comment?: boolean })._is_comment,
+      parent_post_id: ((post as unknown as { _parent_post_id?: string | null })._parent_post_id) || null,
+      discord_alert_status: 'pending',
+      status: 'new',
+      fetched_at: new Date().toISOString(),
+      // V2 fields (backward compat)
+      fit_score: fitScore,
+      lead_score: leadScore,
+      engage_score: engageScore,
+      lead_tier: leadTier,
+      is_unseen: true,
+      // V3 fields
+      authenticity_score: authenticityScore,
+      relevance_score: relevanceScore,
+      buyer_intent: buyerIntent,
+      discovery_source: postSource,
+      pipeline_version: 3,
+    };
+  });
+
+  // ---- Upsert with multi-level fallback ----
+  if (signals.length > 0) {
+    const { error: upsertError } = await supabase
+      .from('outreach_signals')
+      .upsert(signals, { onConflict: 'project_id,reddit_id' });
+
+    if (upsertError) {
+      // Strip V3 columns and retry with V2
+      const withoutV3 = signals.map(({ authenticity_score, relevance_score, buyer_intent, discovery_source, pipeline_version, ...rest }) => rest);
+      const { error: retryV2Error } = await supabase
+        .from('outreach_signals')
+        .upsert(withoutV3, { onConflict: 'project_id,reddit_id' });
+
+      if (retryV2Error) {
+        // Strip V2 columns too
+        const withoutV2 = withoutV3.map(({ fit_score, lead_score, engage_score, lead_tier, is_unseen, ...rest }) => rest);
+        const { error: retryBaseError } = await supabase
+          .from('outreach_signals')
+          .upsert(withoutV2, { onConflict: 'project_id,reddit_id' });
+
+        if (retryBaseError) {
+          // Final fallback with base fields only
+          const baseSignals = signals.map((s) => ({
+            project_id: s.project_id,
+            reddit_id: s.reddit_id,
+            subreddit: s.subreddit,
+            title: s.title,
+            body: s.body,
+            author: s.author,
+            score: s.score,
+            num_comments: s.num_comments,
+            permalink: s.permalink,
+            created_utc: s.created_utc,
+            intent_type: s.intent_type,
+            intent_score: s.intent_score,
+            combined_score: s.combined_score,
+            matched_keywords: s.matched_keywords,
+            competitor_mentioned: s.competitor_mentioned,
+            status: s.status,
+            fetched_at: s.fetched_at,
+          }));
+          await supabase
+            .from('outreach_signals')
+            .upsert(baseSignals, { onConflict: 'project_id,reddit_id' });
+        }
+      }
+    }
+  }
+
+  // ---- Upsert competitor mentions ----
+  try {
+    const competitorMentionRows: {
+      project_id: string;
+      signal_id: string | undefined;
+      competitor_name: string;
+      mention_context: string;
+      sentiment: string;
+      switching_intent: boolean;
+    }[] = [];
+
+    for (const post of filteredPosts) {
+      const v3 = v3Classifications.get(post.id);
+      if (v3?.competitor_mentions && v3.competitor_mentions.length > 0) {
+        for (const cm of v3.competitor_mentions) {
+          competitorMentionRows.push({
+            project_id: projectId,
+            signal_id: undefined,
+            competitor_name: cm.name,
+            mention_context: cm.context,
+            sentiment: cm.sentiment,
+            switching_intent: cm.switching_intent,
+          });
+        }
+      }
+    }
+
+    if (competitorMentionRows.length > 0) {
+      const redditIds = filteredPosts
+        .filter((p) => v3Classifications.has(p.id) && (v3Classifications.get(p.id)?.competitor_mentions?.length ?? 0) > 0)
+        .map((p) => p.id);
+
+      const { data: signalRows } = await supabase
+        .from('outreach_signals')
+        .select('id, reddit_id')
+        .eq('project_id', projectId)
+        .in('reddit_id', redditIds);
+
+      const signalIdMap = new Map(
+        (signalRows || []).map((s: { id: string; reddit_id: string }) => [s.reddit_id, s.id])
+      );
+
+      let mentionIdx = 0;
+      for (const post of filteredPosts) {
+        const v3 = v3Classifications.get(post.id);
+        const mentionCount = v3?.competitor_mentions?.length ?? 0;
+        for (let i = 0; i < mentionCount && mentionIdx < competitorMentionRows.length; i++) {
+          competitorMentionRows[mentionIdx].signal_id = signalIdMap.get(post.id);
+          mentionIdx++;
+        }
+      }
+
+      const validMentions = competitorMentionRows.filter((m) => m.signal_id);
+      if (validMentions.length > 0) {
+        await supabase.from('competitor_mentions').insert(validMentions);
+      }
+    }
+  } catch {
+    // competitor_mentions table may not exist yet
   }
 
   return signals.length;

--- a/app/src/lib/outreach/scoring.ts
+++ b/app/src/lib/outreach/scoring.ts
@@ -57,7 +57,7 @@ export function computeCombinedScore(
 
 // ---- V2 Scoring ----
 
-import type { LeadTier } from '@/types';
+import type { LeadTier, BuyerIntent } from '@/types';
 
 export function computeV2CombinedScore(fitScore: number, leadScore: number, engageScore: number): number {
   return (fitScore * 0.4 + leadScore * 0.35 + engageScore * 0.25) / 10;
@@ -66,6 +66,18 @@ export function computeV2CombinedScore(fitScore: number, leadScore: number, enga
 export function deriveLeadTier(fitScore: number, leadScore: number): LeadTier {
   if (fitScore >= 8 && leadScore >= 7) return 'hot';
   if (fitScore >= 6 && leadScore >= 5) return 'warm';
+  return 'cold';
+}
+
+// ---- V3 Scoring ----
+
+export function computeV3CombinedScore(fit: number, lead: number, authenticity: number, relevance: number): number {
+  return (fit * 0.30 + lead * 0.30 + authenticity * 0.20 + relevance * 0.20) / 10;
+}
+
+export function deriveLeadTierV3(fit: number, lead: number, authenticity: number, relevance: number): LeadTier {
+  if (fit >= 7 && lead >= 7 && authenticity >= 6 && relevance >= 5) return 'hot';
+  if (fit >= 5 && lead >= 5 && authenticity >= 4) return 'warm';
   return 'cold';
 }
 

--- a/app/src/lib/outreach/signal-classifier.ts
+++ b/app/src/lib/outreach/signal-classifier.ts
@@ -6,8 +6,15 @@
  */
 
 import { getAnthropicClient, HAIKU_MODEL, AI_MODEL } from '@/lib/ai/client';
-import { SIGNAL_ANALYSIS_SYSTEM_PROMPT, SIGNAL_ANALYSIS_V2_SYSTEM_PROMPT, buildV2ClassificationPrompt } from '@/lib/ai/prompts';
-import type { SignalType, PainSeverity, ScoreBin } from '@/types';
+import {
+  SIGNAL_ANALYSIS_SYSTEM_PROMPT,
+  SIGNAL_ANALYSIS_V2_SYSTEM_PROMPT,
+  buildV2ClassificationPrompt,
+  PRE_FILTER_SYSTEM_PROMPT,
+  SIGNAL_ANALYSIS_V3_SYSTEM_PROMPT,
+  buildV3ClassificationPrompt,
+} from '@/lib/ai/prompts';
+import type { SignalType, PainSeverity, ScoreBin, BuyerIntent } from '@/types';
 
 export interface ClassificationInput {
   reddit_id: string;
@@ -357,6 +364,153 @@ function parseClassificationResponse(responseText: string): ClassificationResult
     return (parsed.classifications || []).map((c) => ({
       ...c,
       intent_score: BIN_TO_SCORE[c.score_bin] ?? 0.5,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+// ---- V3 Classification (4-dimension scoring + buyer intent) ----
+
+export interface ClassificationResultV3 {
+  reddit_id: string;
+  intent_type: string;
+  fit_score: number;
+  lead_score: number;
+  authenticity_score: number;
+  relevance_score: number;
+  buyer_intent: BuyerIntent;
+  signal_types: SignalType[];
+  pain_severity: PainSeverity | null;
+  decision_maker: boolean;
+  competitor_mentions: { name: string; sentiment: string; switching_intent: boolean; context: string }[];
+}
+
+const VALID_BUYER_INTENTS: BuyerIntent[] = ['problem_aware', 'solution_seeking', 'comparing', 'ready_to_buy'];
+
+/**
+ * Pre-filter posts by title using a cheap Haiku call.
+ * Returns indices of posts that pass the filter.
+ */
+export async function preFilterPosts(
+  posts: { index: number; title: string }[],
+  productContext: { productName: string; productDescription: string }
+): Promise<number[]> {
+  if (posts.length === 0) return [];
+
+  const client = getAnthropicClient();
+
+  const titleList = posts
+    .map((p) => `${p.index}. ${p.title}`)
+    .join('\n');
+
+  const userPrompt = `## Product
+- **Name:** ${productContext.productName}
+- **Description:** ${productContext.productDescription}
+
+## Post Titles
+${titleList}
+
+Return the indices of titles that could be from potential leads.`;
+
+  const message = await client.messages.create({
+    model: HAIKU_MODEL,
+    max_tokens: 1024,
+    system: PRE_FILTER_SYSTEM_PROMPT,
+    messages: [{ role: 'user', content: userPrompt }],
+  });
+
+  const textContent = message.content.find((c) => c.type === 'text');
+  if (!textContent || textContent.type !== 'text') return posts.map((p) => p.index);
+
+  let text = textContent.text.trim();
+  if (text.startsWith('```')) {
+    text = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+  }
+
+  try {
+    const parsed = JSON.parse(text) as { indices: number[] };
+    return parsed.indices || [];
+  } catch {
+    // If parsing fails, pass all posts through (be inclusive)
+    return posts.map((p) => p.index);
+  }
+}
+
+/**
+ * Classify posts using V3 4-dimension scoring + buyer intent.
+ */
+export async function classifyPostsV3(
+  posts: ClassificationInput[],
+  productContext: {
+    productName: string;
+    productDescription: string;
+    problemsSolved?: string[];
+    solutionFeatures?: string[];
+    audienceBehaviors?: string[];
+    competitors?: string[];
+    competitorWeaknesses?: string[];
+  }
+): Promise<ClassificationResultV3[]> {
+  if (posts.length === 0) return [];
+
+  const client = getAnthropicClient();
+  const prompt = buildV3ClassificationPrompt(
+    posts.map((p) => ({
+      reddit_id: p.reddit_id,
+      title: p.title,
+      body: p.body,
+      subreddit: p.subreddit,
+      author: p.author,
+      score: p.score,
+      num_comments: p.num_comments,
+    })),
+    productContext
+  );
+
+  const message = await client.messages.create({
+    model: HAIKU_MODEL,
+    max_tokens: 4096,
+    system: SIGNAL_ANALYSIS_V3_SYSTEM_PROMPT,
+    messages: [{ role: 'user', content: prompt }],
+  });
+
+  const textContent = message.content.find((c) => c.type === 'text');
+  if (!textContent || textContent.type !== 'text') return [];
+
+  return parseV3ClassificationResponse(textContent.text);
+}
+
+function parseV3ClassificationResponse(responseText: string): ClassificationResultV3[] {
+  let text = responseText.trim();
+  if (text.startsWith('```')) {
+    text = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+  }
+
+  try {
+    const parsed = JSON.parse(text) as {
+      classifications: {
+        reddit_id: string;
+        intent_type: string;
+        fit_score: number;
+        lead_score: number;
+        authenticity_score: number;
+        relevance_score: number;
+        buyer_intent: BuyerIntent;
+        signal_types: SignalType[];
+        pain_severity: PainSeverity | null;
+        decision_maker: boolean;
+        competitor_mentions: { name: string; sentiment: string; switching_intent: boolean; context: string }[];
+      }[];
+    };
+
+    return (parsed.classifications || []).map((c) => ({
+      ...c,
+      fit_score: Math.max(1, Math.min(10, c.fit_score)),
+      lead_score: Math.max(1, Math.min(10, c.lead_score)),
+      authenticity_score: Math.max(1, Math.min(10, c.authenticity_score)),
+      relevance_score: Math.max(1, Math.min(10, c.relevance_score)),
+      buyer_intent: VALID_BUYER_INTENTS.includes(c.buyer_intent) ? c.buyer_intent : 'problem_aware',
     }));
   } catch {
     return [];

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -334,9 +334,19 @@ export interface OutreachSignal {
   lead_tier: 'hot' | 'warm' | 'cold' | null;
   is_unseen: boolean;
   is_favorited: boolean;
+  // V3 scoring
+  authenticity_score: number | null;
+  relevance_score: number | null;
+  buyer_intent: BuyerIntent | null;
+  discovery_source: DiscoverySource | null;
+  pipeline_version: number | null;
 }
 
 export type LeadTier = 'hot' | 'warm' | 'cold';
+
+export type BuyerIntent = 'problem_aware' | 'solution_seeking' | 'comparing' | 'ready_to_buy';
+
+export type DiscoverySource = 'subreddit_browse' | 'keyword_search' | 'comment_search' | 'both';
 
 export type AlertChannel = 'discord' | 'slack' | 'email' | 'telegram';
 

--- a/app/supabase/migrations/016_pipeline_v3.sql
+++ b/app/supabase/migrations/016_pipeline_v3.sql
@@ -1,0 +1,17 @@
+-- Pipeline V3: Add 4-dimension scoring, buyer intent, and discovery source tracking
+-- All columns nullable for backward compatibility with existing signals
+
+ALTER TABLE outreach_signals
+  ADD COLUMN IF NOT EXISTS authenticity_score REAL,
+  ADD COLUMN IF NOT EXISTS relevance_score REAL,
+  ADD COLUMN IF NOT EXISTS buyer_intent TEXT,
+  ADD COLUMN IF NOT EXISTS discovery_source TEXT DEFAULT 'keyword_search',
+  ADD COLUMN IF NOT EXISTS pipeline_version INTEGER DEFAULT 2;
+
+-- Indexes for filtering by buyer intent and pipeline version
+CREATE INDEX IF NOT EXISTS idx_outreach_signals_buyer_intent
+  ON outreach_signals (buyer_intent)
+  WHERE buyer_intent IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_outreach_signals_pipeline_version
+  ON outreach_signals (pipeline_version);


### PR DESCRIPTION
## Summary
- **Subreddit browsing**: Now browses all posts in monitored subreddits (not just keyword search), catching posts like "Got $350 to spend" that no keyword would find
- **AI pre-filter**: Replaces regex Tier 1 with cheap Haiku batch call on titles (~$0.01/day), with regex fallback on failure
- **4-dimension scoring**: Fit, Authenticity, Relevance, Lead (replaces 3D Fit/Lead/Engage) with authenticity gate preventing bots from becoming hot leads
- **Buyer intent labels**: Problem Aware / Solution Seeking / Comparing / Ready to Buy with journey-stage filter pills on the signals page
- **Full backward compat**: V2/V1 signals render with their original layouts, engage_score and intent_type still populated

## Test plan
- [ ] Apply migration 016 to Supabase (adds authenticity_score, relevance_score, buyer_intent, discovery_source, pipeline_version columns)
- [ ] Trigger "Scan Now" and verify signals appear from subreddit browsing (not just keyword matches)
- [ ] Verify new signals have 4 score badges (Fit/Auth/Rel/Lead) and buyer intent badge on SignalCard
- [ ] Verify old signals still render with 3-badge V2 or single-score V1 layout
- [ ] Test buyer intent filter pills on signals page
- [ ] Check discovery_source shows "browse" / "browse+keyword" labels on cards found via browsing
- [ ] Verify cron poll-signals route works with V3 pipeline
- [ ] Monitor Anthropic usage to confirm costs stay within ~$2-4/month budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)