### PR TITLE
Fix scan wizard reopening on every Signals visit

### DIFF
--- a/app/src/app/projects/[id]/outreach/signals/page.tsx
+++ b/app/src/app/projects/[id]/outreach/signals/page.tsx
@@ -87,14 +87,22 @@ export default function OutreachSignalsPage() {
     fetchAnalytics();
   }, [fetchSignals, fetchAnalytics]);
 
-  // Check wizard completion status on mount
+  // Check wizard completion status on mount — only show on first visit
   useEffect(() => {
+    const localKey = `sr_wizard_done_${project.id}`;
+    if (localStorage.getItem(localKey)) {
+      setWizardChecked(true);
+      return;
+    }
+
     async function checkWizard() {
       try {
         const res = await fetch(`/api/outreach/config?project_id=${project.id}`);
         const json = await res.json();
         if (!json.config?.scan_wizard_completed) {
           setWizardOpen(true);
+        } else {
+          localStorage.setItem(localKey, '1');
         }
       } catch {
         // Config may not exist — show wizard
@@ -445,11 +453,17 @@ export default function OutreachSignalsPage() {
         onScanRequested={handleScanNow}
       />
 
-      {/* Scan Wizard (first visit) */}
+      {/* Scan Wizard (first visit only) */}
       {wizardChecked && (
         <ScanWizard
           open={wizardOpen}
-          onOpenChange={setWizardOpen}
+          onOpenChange={(open) => {
+            setWizardOpen(open);
+            if (!open) {
+              // Mark as seen so it doesn't reappear on revisit
+              localStorage.setItem(`sr_wizard_done_${project.id}`, '1');
+            }
+          }}
           projectId={project.id}
           onComplete={handleScanNow}
         />


### PR DESCRIPTION
## Summary
- Use localStorage to remember when the scan wizard has been shown/dismissed
- Previously it only marked complete if the user finished all steps — closing it early caused it to reappear every visit
- The "Parameters" button remains available for adjusting scan settings anytime

## Test plan
- [ ] First visit to Signals shows the wizard
- [ ] Dismissing or completing the wizard prevents it from reappearing on revisit
- [ ] Parameters button still opens scan config modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)