### PR TITLE
Replace broken iframe side panel with native activity hub UI

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -8,6 +8,8 @@ const THEY_REPLIED_KEY = 'sr_they_replied';
 const PREVIEWS_KEY = 'sr_chat_previews';
 const CONVERSATIONS_KEY = 'sr_conversations';
 const SCAN_READY_KEY = 'sr_scan_ready';
+const ACTIVITY_LOG_KEY = 'sr_activity_log';
+const ACTIVITY_LOG_MAX = 50;
 
 const SCAN_ALARM = 'sr_periodic_scan';
 const MSG_FETCH_ALARM = 'sr_message_fetch';
@@ -20,6 +22,17 @@ let composeTabId = null;
 
 const CHAT_URLS_KEY = 'sr_chat_urls';
 const CONVERSATION_CACHE_TTL = 5 * 60 * 1000;
+
+// ---- Activity Logging ----
+
+function logActivity(message, type = 'info') {
+  chrome.storage.local.get(ACTIVITY_LOG_KEY, (result) => {
+    const log = result[ACTIVITY_LOG_KEY] || [];
+    log.unshift({ message, type, timestamp: Date.now() });
+    if (log.length > ACTIVITY_LOG_MAX) log.length = ACTIVITY_LOG_MAX;
+    chrome.storage.local.set({ [ACTIVITY_LOG_KEY]: log });
+  });
+}
 
 // ---- On install/update: start periodic scanning ----
 chrome.runtime.onInstalled.addListener((details) => {
@@ -370,10 +383,16 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         });
 
         lastSendDmTime = Date.now();
+        if (result.success) {
+          logActivity(`DM sent to u/${username}`, 'send');
+        } else {
+          logActivity(`DM failed for u/${username}: ${result.error}`, 'error');
+        }
         sendResponse(result);
       } catch (err) {
         console.log('[SR BG] SEND_DM error:', err.message);
         pendingSendDm = null;
+        logActivity(`DM error: ${err.message}`, 'error');
         sendResponse({ success: false, error: err.message });
       }
     })();
@@ -410,6 +429,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     } else {
       // Manual mode — no pending send. Store result so web app can poll for it.
       console.log('[SR BG] COMPOSE_RESULT (manual mode): success=' + success + ' user=' + username);
+      if (success) {
+        logActivity(`DM sent to u/${username} (manual)`, 'send');
+      } else {
+        logActivity(`DM failed for u/${username}: ${error || 'unknown'}`, 'error');
+      }
       if (success && username) {
         // Add to youSentTo storage
         chrome.storage.local.get(YOU_SENT_TO_KEY, (result) => {
@@ -612,6 +636,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'CHAT_SCAN_RESULT') {
     const { usernames = [], youSentTo = [], theyReplied = [], previews = {}, chatUrls = {} } = message;
     console.log(`[SR BG] Chat scan complete: ${usernames.length} usernames, ${youSentTo.length} youSentTo, ${theyReplied.length} theyReplied`);
+    logActivity(`Scan completed — ${usernames.length} chats found`, 'scan');
     if (usernames.length > 0) {
       // Usernames — cumulative
       chrome.storage.local.get(STORAGE_KEY, (result) => {
@@ -1161,8 +1186,14 @@ async function storeScrapedMessages(userLower, scraped) {
 
 // ---- Response Handlers ----
 
+let lastKnownLoginStatus = null;
+
 async function handleCheckStatus() {
   const hasSession = await hasRedditSession();
+  if (lastKnownLoginStatus !== null && lastKnownLoginStatus !== hasSession) {
+    logActivity(hasSession ? 'Reddit session detected — logged in' : 'Reddit session lost — logged out', hasSession ? 'info' : 'error');
+  }
+  lastKnownLoginStatus = hasSession;
   if (!hasSession) {
     return { installed: true, redditLoggedIn: false, username: null, capturedCount: 0, youSentToCount: 0, theyRepliedCount: 0 };
   }

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -3,57 +3,535 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Reddit Chat — SuperReddit</title>
+  <title>SuperReddit</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
-    html, body { height: 100%; overflow: hidden; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+    html, body {
+      height: 100%;
+      overflow: hidden;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #1a1a1b;
+      color: #d7dadc;
+      font-size: 13px;
+    }
 
-    .status-bar {
+    /* ---- Layout ---- */
+    .app {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    /* ---- Header ---- */
+    .header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 12px;
+      background: #1a1a1b;
+      border-bottom: 1px solid #343536;
+      flex-shrink: 0;
+    }
+    .header-brand {
+      font-weight: 700;
+      font-size: 15px;
+      color: #ff4500;
+    }
+    .header-status {
       display: flex;
       align-items: center;
       gap: 6px;
-      padding: 6px 10px;
-      background: #1a1a1b;
-      border-bottom: 1px solid #343536;
+      margin-left: auto;
       font-size: 11px;
       color: #818384;
     }
     .status-dot {
-      width: 6px;
-      height: 6px;
+      width: 8px;
+      height: 8px;
       border-radius: 50%;
-      background: #46d160;
+      background: #818384;
       flex-shrink: 0;
+      transition: background 0.3s;
     }
-    .status-dot.scanning { animation: pulse 1.5s infinite; }
+    .status-dot.connected { background: #46d160; }
+    .status-dot.disconnected { background: #ea0027; }
+    .status-dot.scanning {
+      background: #ff4500;
+      animation: pulse 1.5s infinite;
+    }
     @keyframes pulse {
       0%, 100% { opacity: 1; }
       50% { opacity: 0.4; }
     }
-    .status-bar .count {
-      margin-left: auto;
+
+    /* ---- Stats Row ---- */
+    .stats-row {
+      display: flex;
+      gap: 8px;
+      padding: 8px 12px;
+      border-bottom: 1px solid #343536;
+      flex-shrink: 0;
+    }
+    .stat-card {
+      flex: 1;
+      background: #272729;
+      border-radius: 8px;
+      padding: 8px 10px;
+      text-align: center;
+    }
+    .stat-value {
+      font-size: 18px;
+      font-weight: 700;
       color: #d7dadc;
-      font-weight: 500;
+      line-height: 1.2;
+    }
+    .stat-label {
+      font-size: 10px;
+      color: #818384;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
     }
 
-    iframe {
-      width: 100%;
-      height: calc(100% - 29px);
-      border: none;
+    /* ---- Tabs ---- */
+    .tab-bar {
+      display: flex;
+      border-bottom: 1px solid #343536;
+      flex-shrink: 0;
     }
+    .tab-btn {
+      flex: 1;
+      background: none;
+      border: none;
+      padding: 10px;
+      font-size: 13px;
+      font-weight: 600;
+      color: #818384;
+      cursor: pointer;
+      border-bottom: 2px solid transparent;
+      transition: color 0.2s, border-color 0.2s;
+      font-family: inherit;
+    }
+    .tab-btn:hover { color: #d7dadc; }
+    .tab-btn.active {
+      color: #ff4500;
+      border-bottom-color: #ff4500;
+    }
+
+    /* ---- Tab Content ---- */
+    .tab-content {
+      flex: 1;
+      overflow: hidden;
+      position: relative;
+    }
+    .tab-panel {
+      display: none;
+      flex-direction: column;
+      height: 100%;
+      overflow: hidden;
+    }
+    .tab-panel.active {
+      display: flex;
+    }
+
+    /* ---- Search ---- */
+    .search-bar {
+      padding: 8px 12px;
+      flex-shrink: 0;
+    }
+    .search-input {
+      width: 100%;
+      background: #272729;
+      border: 1px solid #343536;
+      border-radius: 6px;
+      padding: 7px 10px;
+      color: #d7dadc;
+      font-size: 12px;
+      outline: none;
+      font-family: inherit;
+      transition: border-color 0.2s;
+    }
+    .search-input::placeholder { color: #818384; }
+    .search-input:focus { border-color: #ff4500; }
+
+    /* ---- Conversation List ---- */
+    .conversation-list {
+      flex: 1;
+      overflow-y: auto;
+      padding: 0 8px 80px;
+    }
+    .conversation-list::-webkit-scrollbar { width: 6px; }
+    .conversation-list::-webkit-scrollbar-track { background: transparent; }
+    .conversation-list::-webkit-scrollbar-thumb { background: #343536; border-radius: 3px; }
+
+    .conversation-card {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 10px;
+      border-radius: 8px;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    .conversation-card:hover { background: #272729; }
+
+    .convo-avatar {
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      background: #343536;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 14px;
+      font-weight: 700;
+      color: #818384;
+      flex-shrink: 0;
+      text-transform: uppercase;
+    }
+    .convo-body {
+      flex: 1;
+      min-width: 0;
+    }
+    .convo-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 2px;
+    }
+    .convo-username {
+      font-weight: 600;
+      font-size: 13px;
+      color: #d7dadc;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .convo-badge {
+      font-size: 9px;
+      font-weight: 700;
+      padding: 1px 5px;
+      border-radius: 3px;
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+      flex-shrink: 0;
+    }
+    .convo-badge.sent { background: rgba(36, 160, 237, 0.15); color: #24a0ed; }
+    .convo-badge.replied { background: rgba(70, 209, 96, 0.15); color: #46d160; }
+    .convo-badge.new { background: rgba(129, 131, 132, 0.15); color: #818384; }
+    .convo-preview {
+      font-size: 12px;
+      color: #818384;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .convo-meta {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 2px;
+      flex-shrink: 0;
+    }
+    .convo-time {
+      font-size: 10px;
+      color: #818384;
+    }
+
+    .empty-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      color: #818384;
+      text-align: center;
+      padding: 20px;
+    }
+    .empty-state-icon {
+      font-size: 32px;
+      margin-bottom: 8px;
+      opacity: 0.5;
+    }
+    .empty-state-text {
+      font-size: 13px;
+      line-height: 1.4;
+    }
+
+    /* ---- Activity Log ---- */
+    .activity-list {
+      flex: 1;
+      overflow-y: auto;
+      padding: 8px 12px 80px;
+    }
+    .activity-list::-webkit-scrollbar { width: 6px; }
+    .activity-list::-webkit-scrollbar-track { background: transparent; }
+    .activity-list::-webkit-scrollbar-thumb { background: #343536; border-radius: 3px; }
+
+    .activity-entry {
+      display: flex;
+      gap: 8px;
+      padding: 8px 0;
+      border-bottom: 1px solid #272729;
+      font-size: 12px;
+    }
+    .activity-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      margin-top: 5px;
+      flex-shrink: 0;
+    }
+    .activity-dot.scan { background: #ff4500; }
+    .activity-dot.send { background: #46d160; }
+    .activity-dot.error { background: #ea0027; }
+    .activity-dot.info { background: #24a0ed; }
+    .activity-message {
+      flex: 1;
+      color: #d7dadc;
+      line-height: 1.4;
+    }
+    .activity-time {
+      font-size: 10px;
+      color: #818384;
+      flex-shrink: 0;
+      white-space: nowrap;
+    }
+
+    /* ---- FAB ---- */
+    .fab {
+      position: fixed;
+      bottom: 16px;
+      right: 16px;
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      background: #ff4500;
+      border: none;
+      color: white;
+      font-size: 24px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+      transition: transform 0.15s, background 0.15s;
+      z-index: 100;
+    }
+    .fab:hover {
+      background: #e03d00;
+      transform: scale(1.05);
+    }
+
+    /* ---- Compose Modal ---- */
+    .modal-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.6);
+      z-index: 200;
+      align-items: flex-end;
+      justify-content: center;
+    }
+    .modal-overlay.open { display: flex; }
+    .modal {
+      width: 100%;
+      max-width: 400px;
+      background: #1a1a1b;
+      border-top: 1px solid #343536;
+      border-radius: 12px 12px 0 0;
+      padding: 16px;
+      animation: slideUp 0.2s ease-out;
+    }
+    @keyframes slideUp {
+      from { transform: translateY(100%); }
+      to { transform: translateY(0); }
+    }
+    .modal-title {
+      font-size: 15px;
+      font-weight: 700;
+      margin-bottom: 12px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .modal-close {
+      background: none;
+      border: none;
+      color: #818384;
+      font-size: 20px;
+      cursor: pointer;
+      padding: 4px;
+      line-height: 1;
+    }
+    .modal-close:hover { color: #d7dadc; }
+    .modal-field {
+      margin-bottom: 10px;
+    }
+    .modal-field label {
+      display: block;
+      font-size: 11px;
+      color: #818384;
+      margin-bottom: 4px;
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+    }
+    .modal-field input,
+    .modal-field textarea {
+      width: 100%;
+      background: #272729;
+      border: 1px solid #343536;
+      border-radius: 6px;
+      padding: 8px 10px;
+      color: #d7dadc;
+      font-size: 13px;
+      font-family: inherit;
+      outline: none;
+      transition: border-color 0.2s;
+    }
+    .modal-field input:focus,
+    .modal-field textarea:focus { border-color: #ff4500; }
+    .modal-field textarea {
+      resize: vertical;
+      min-height: 80px;
+    }
+    .modal-actions {
+      display: flex;
+      gap: 8px;
+      margin-top: 12px;
+    }
+    .btn {
+      flex: 1;
+      padding: 10px;
+      border-radius: 8px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      border: none;
+      font-family: inherit;
+      transition: opacity 0.15s;
+    }
+    .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .btn-primary {
+      background: #ff4500;
+      color: white;
+    }
+    .btn-primary:hover:not(:disabled) { background: #e03d00; }
+    .btn-secondary {
+      background: #272729;
+      color: #d7dadc;
+      border: 1px solid #343536;
+    }
+    .btn-secondary:hover:not(:disabled) { background: #343536; }
+
+    /* ---- Toast ---- */
+    .toast {
+      position: fixed;
+      bottom: 72px;
+      left: 50%;
+      transform: translateX(-50%) translateY(20px);
+      background: #272729;
+      color: #d7dadc;
+      padding: 8px 16px;
+      border-radius: 8px;
+      font-size: 12px;
+      font-weight: 500;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+      opacity: 0;
+      transition: opacity 0.2s, transform 0.2s;
+      z-index: 300;
+      pointer-events: none;
+      white-space: nowrap;
+    }
+    .toast.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+    .toast.success { border-left: 3px solid #46d160; }
+    .toast.error { border-left: 3px solid #ea0027; }
   </style>
 </head>
 <body>
-  <div class="status-bar">
-    <div class="status-dot scanning" id="statusDot"></div>
-    <span id="statusText">Scanning chats...</span>
-    <span class="count" id="countBadge"></span>
+  <div class="app">
+    <!-- Header -->
+    <div class="header">
+      <span class="header-brand">SuperReddit</span>
+      <div class="header-status">
+        <div class="status-dot" id="statusDot"></div>
+        <span id="statusText">Checking...</span>
+      </div>
+    </div>
+
+    <!-- Stats Row -->
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value" id="statChats">—</div>
+        <div class="stat-label">Chats</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value" id="statSent">—</div>
+        <div class="stat-label">Sent</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value" id="statReplies">—</div>
+        <div class="stat-label">Replies</div>
+      </div>
+    </div>
+
+    <!-- Tab Bar -->
+    <div class="tab-bar">
+      <button class="tab-btn active" data-tab="conversations">Conversations</button>
+      <button class="tab-btn" data-tab="activity">Activity</button>
+    </div>
+
+    <!-- Tab Content -->
+    <div class="tab-content">
+      <!-- Conversations Tab -->
+      <div class="tab-panel active" id="tab-conversations">
+        <div class="search-bar">
+          <input type="text" class="search-input" id="searchInput" placeholder="Search by username...">
+        </div>
+        <div class="conversation-list" id="conversationList"></div>
+      </div>
+
+      <!-- Activity Tab -->
+      <div class="tab-panel" id="tab-activity">
+        <div class="activity-list" id="activityList"></div>
+      </div>
+    </div>
   </div>
-  <iframe
-    id="chatFrame"
-    src="https://www.reddit.com/chat"
-    allow="clipboard-write"
-  ></iframe>
+
+  <!-- Quick Compose FAB -->
+  <button class="fab" id="composeFab" title="Compose DM">+</button>
+
+  <!-- Compose Modal -->
+  <div class="modal-overlay" id="composeModal">
+    <div class="modal">
+      <div class="modal-title">
+        <span>Compose DM</span>
+        <button class="modal-close" id="modalClose">&times;</button>
+      </div>
+      <div class="modal-field">
+        <label for="composeUsername">To (username)</label>
+        <input type="text" id="composeUsername" placeholder="e.g. spez">
+      </div>
+      <div class="modal-field">
+        <label for="composeSubject">Subject</label>
+        <input type="text" id="composeSubject" placeholder="Message subject">
+      </div>
+      <div class="modal-field">
+        <label for="composeBody">Message</label>
+        <textarea id="composeBody" placeholder="Write your message..."></textarea>
+      </div>
+      <div class="modal-actions">
+        <button class="btn btn-secondary" id="composeOpenReddit">Open on Reddit</button>
+        <button class="btn btn-primary" id="composeSend">Send</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Toast -->
+  <div class="toast" id="toast"></div>
+
   <script src="sidepanel.js"></script>
 </body>
 </html>

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -1,37 +1,373 @@
-// SuperReddit Side Panel — Status indicator for the embedded Reddit chat
-// The reddit-content.js content script runs inside the iframe (all_frames: true)
-// and handles all scanning. This script just shows live status.
+// SuperReddit Side Panel — Activity Hub with Quick Compose
+// Reads all data from chrome.storage.local (populated by background.js + content scripts)
 
+const STORAGE_KEYS = {
+  usernames: 'sr_chat_usernames',
+  youSentTo: 'sr_you_sent_to',
+  theyReplied: 'sr_they_replied',
+  previews: 'sr_chat_previews',
+  conversations: 'sr_conversations',
+  activityLog: 'sr_activity_log',
+};
+
+// ---- DOM refs ----
 const statusDot = document.getElementById('statusDot');
 const statusText = document.getElementById('statusText');
-const countBadge = document.getElementById('countBadge');
+const statChats = document.getElementById('statChats');
+const statSent = document.getElementById('statSent');
+const statReplies = document.getElementById('statReplies');
+const searchInput = document.getElementById('searchInput');
+const conversationList = document.getElementById('conversationList');
+const activityList = document.getElementById('activityList');
+const composeFab = document.getElementById('composeFab');
+const composeModal = document.getElementById('composeModal');
+const modalClose = document.getElementById('modalClose');
+const composeUsername = document.getElementById('composeUsername');
+const composeSubject = document.getElementById('composeSubject');
+const composeBody = document.getElementById('composeBody');
+const composeSend = document.getElementById('composeSend');
+const composeOpenReddit = document.getElementById('composeOpenReddit');
+const toast = document.getElementById('toast');
 
-function updateStatus() {
-  chrome.storage.local.get(['sr_chat_usernames', 'sr_chat_replies'], (result) => {
-    const usernames = result.sr_chat_usernames || [];
-    const replies = result.sr_chat_replies || [];
+// ---- State ----
+let cachedData = {
+  usernames: [],
+  youSentTo: [],
+  theyReplied: [],
+  previews: {},
+  conversations: {},
+  activityLog: [],
+};
 
-    if (usernames.length === 0) {
-      statusDot.className = 'status-dot scanning';
-      statusText.textContent = 'Scanning chats...';
-      countBadge.textContent = '';
+// ---- Init ----
+loadAllData().then(() => {
+  renderConversations();
+  renderActivity();
+  updateStats();
+});
+checkRedditStatus();
+setInterval(checkRedditStatus, 30000);
+
+// ---- Tab Switching ----
+document.querySelectorAll('.tab-btn').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    document.querySelectorAll('.tab-btn').forEach((b) => b.classList.remove('active'));
+    document.querySelectorAll('.tab-panel').forEach((p) => p.classList.remove('active'));
+    btn.classList.add('active');
+    document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+  });
+});
+
+// ---- Search ----
+searchInput.addEventListener('input', () => {
+  renderConversations();
+});
+
+// ---- Compose Modal ----
+composeFab.addEventListener('click', () => openCompose());
+modalClose.addEventListener('click', () => closeCompose());
+composeModal.addEventListener('click', (e) => {
+  if (e.target === composeModal) closeCompose();
+});
+
+composeSend.addEventListener('click', () => handleSend());
+composeOpenReddit.addEventListener('click', () => handleOpenOnReddit());
+
+// ---- Storage Change Listener ----
+chrome.storage.onChanged.addListener((changes) => {
+  let needsRender = false;
+  for (const [storageKey, dataKey] of Object.entries({
+    [STORAGE_KEYS.usernames]: 'usernames',
+    [STORAGE_KEYS.youSentTo]: 'youSentTo',
+    [STORAGE_KEYS.theyReplied]: 'theyReplied',
+    [STORAGE_KEYS.previews]: 'previews',
+    [STORAGE_KEYS.conversations]: 'conversations',
+    [STORAGE_KEYS.activityLog]: 'activityLog',
+  })) {
+    if (changes[storageKey]) {
+      cachedData[dataKey] = changes[storageKey].newValue || (Array.isArray(cachedData[dataKey]) ? [] : {});
+      needsRender = true;
+    }
+  }
+  if (needsRender) {
+    renderConversations();
+    renderActivity();
+    updateStats();
+  }
+});
+
+// ---- Data Loading ----
+
+async function loadAllData() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(Object.values(STORAGE_KEYS), (result) => {
+      cachedData.usernames = result[STORAGE_KEYS.usernames] || [];
+      cachedData.youSentTo = result[STORAGE_KEYS.youSentTo] || [];
+      cachedData.theyReplied = result[STORAGE_KEYS.theyReplied] || [];
+      cachedData.previews = result[STORAGE_KEYS.previews] || {};
+      cachedData.conversations = result[STORAGE_KEYS.conversations] || {};
+      cachedData.activityLog = result[STORAGE_KEYS.activityLog] || [];
+      resolve();
+    });
+  });
+}
+
+// ---- Reddit Status ----
+
+function checkRedditStatus() {
+  chrome.runtime.sendMessage({ type: 'CHECK_STATUS' }, (response) => {
+    if (chrome.runtime.lastError || !response) {
+      statusDot.className = 'status-dot disconnected';
+      statusText.textContent = 'Error';
+      return;
+    }
+    if (response.redditLoggedIn) {
+      statusDot.className = 'status-dot connected';
+      statusText.textContent = 'Connected';
     } else {
-      statusDot.className = 'status-dot';
-      statusText.textContent = 'Live sync active';
-      const parts = [`${usernames.length} chats`];
-      if (replies.length > 0) parts.push(`${replies.length} replies`);
-      countBadge.textContent = parts.join(' · ');
+      statusDot.className = 'status-dot disconnected';
+      statusText.textContent = 'Not logged in';
     }
   });
 }
 
-// Update every 3s to stay in sync with content script scanning
-updateStatus();
-setInterval(updateStatus, 3000);
+// ---- Stats ----
 
-// Also listen for storage changes for instant updates
-chrome.storage.onChanged.addListener((changes) => {
-  if (changes.sr_chat_usernames || changes.sr_chat_replies) {
-    updateStatus();
+function updateStats() {
+  statChats.textContent = cachedData.usernames.length;
+  statSent.textContent = cachedData.youSentTo.length;
+  statReplies.textContent = cachedData.theyReplied.length;
+}
+
+// ---- Conversations ----
+
+function renderConversations() {
+  const query = searchInput.value.trim().toLowerCase();
+  const sentSet = new Set(cachedData.youSentTo.map((u) => u.toLowerCase()));
+  const repliedSet = new Set(cachedData.theyReplied.map((u) => u.toLowerCase()));
+
+  // Build conversation entries from all known usernames
+  let entries = cachedData.usernames.map((username) => {
+    const uLower = username.toLowerCase();
+    const preview = cachedData.previews[uLower] || null;
+    const convo = cachedData.conversations[uLower] || null;
+
+    // Determine status
+    let status = 'new';
+    if (repliedSet.has(uLower)) status = 'replied';
+    else if (sentSet.has(uLower)) status = 'sent';
+
+    // Get last message timestamp
+    let lastTimestamp = 0;
+    if (convo && convo.messages && convo.messages.length > 0) {
+      lastTimestamp = convo.messages[convo.messages.length - 1].timestamp || 0;
+    } else if (convo && convo.lastUpdated) {
+      lastTimestamp = convo.lastUpdated;
+    }
+
+    // Preview text
+    let previewText = '';
+    if (preview) {
+      previewText = preview.fromYou ? 'You: ' + (preview.text || '') : (preview.text || '');
+    } else if (convo && convo.messages && convo.messages.length > 0) {
+      const lastMsg = convo.messages[convo.messages.length - 1];
+      previewText = lastMsg.isFromYou ? 'You: ' + (lastMsg.text || '') : (lastMsg.text || '');
+    }
+
+    return { username, uLower, status, lastTimestamp, previewText };
+  });
+
+  // Filter by search
+  if (query) {
+    entries = entries.filter((e) => e.uLower.includes(query));
   }
-});
+
+  // Sort: replied first, then sent, then new. Within each group, most recent first.
+  const statusOrder = { replied: 0, sent: 1, new: 2 };
+  entries.sort((a, b) => {
+    const orderDiff = statusOrder[a.status] - statusOrder[b.status];
+    if (orderDiff !== 0) return orderDiff;
+    return b.lastTimestamp - a.lastTimestamp;
+  });
+
+  // Render
+  if (entries.length === 0) {
+    conversationList.innerHTML = `
+      <div class="empty-state">
+        <div class="empty-state-icon">&#x1f4ac;</div>
+        <div class="empty-state-text">${query ? 'No conversations match your search' : 'No conversations yet.<br>Open Reddit chat to start scanning.'}</div>
+      </div>
+    `;
+    return;
+  }
+
+  conversationList.innerHTML = entries.map((entry) => `
+    <div class="conversation-card" data-username="${escapeHtml(entry.username)}">
+      <div class="convo-avatar">${escapeHtml(entry.username.charAt(0))}</div>
+      <div class="convo-body">
+        <div class="convo-header">
+          <span class="convo-username">${escapeHtml(entry.username)}</span>
+          <span class="convo-badge ${entry.status}">${entry.status}</span>
+        </div>
+        <div class="convo-preview">${escapeHtml(truncate(entry.previewText, 60))}</div>
+      </div>
+      <div class="convo-meta">
+        <span class="convo-time">${entry.lastTimestamp ? relativeTime(entry.lastTimestamp) : ''}</span>
+      </div>
+    </div>
+  `).join('');
+
+  // Click handlers
+  conversationList.querySelectorAll('.conversation-card').forEach((card) => {
+    card.addEventListener('click', (e) => {
+      const username = card.dataset.username;
+      // Ctrl/Cmd+click or middle click for compose
+      if (e.ctrlKey || e.metaKey) {
+        openCompose(username);
+      } else {
+        // Open Reddit profile in new tab
+        chrome.tabs.create({ url: 'https://www.reddit.com/user/' + encodeURIComponent(username) });
+      }
+    });
+    // Right-click context: compose
+    card.addEventListener('contextmenu', (e) => {
+      e.preventDefault();
+      openCompose(card.dataset.username);
+    });
+  });
+}
+
+// ---- Activity Log ----
+
+function renderActivity() {
+  const log = cachedData.activityLog;
+
+  if (log.length === 0) {
+    activityList.innerHTML = `
+      <div class="empty-state">
+        <div class="empty-state-icon">&#x1f4cb;</div>
+        <div class="empty-state-text">No activity yet.<br>Events will appear here as the extension works.</div>
+      </div>
+    `;
+    return;
+  }
+
+  activityList.innerHTML = log.map((entry) => `
+    <div class="activity-entry">
+      <div class="activity-dot ${escapeHtml(entry.type || 'info')}"></div>
+      <div class="activity-message">${escapeHtml(entry.message)}</div>
+      <div class="activity-time">${relativeTime(entry.timestamp)}</div>
+    </div>
+  `).join('');
+}
+
+// ---- Compose ----
+
+function openCompose(username) {
+  composeModal.classList.add('open');
+  composeUsername.value = username || '';
+  composeSubject.value = '';
+  composeBody.value = '';
+  composeSend.disabled = false;
+  composeSend.textContent = 'Send';
+  if (username) {
+    composeSubject.focus();
+  } else {
+    composeUsername.focus();
+  }
+}
+
+function closeCompose() {
+  composeModal.classList.remove('open');
+}
+
+function handleSend() {
+  const username = composeUsername.value.trim();
+  const subject = composeSubject.value.trim();
+  const body = composeBody.value.trim();
+
+  if (!username) { showToast('Enter a username', 'error'); return; }
+  if (!subject) { showToast('Enter a subject', 'error'); return; }
+  if (!body) { showToast('Enter a message', 'error'); return; }
+
+  composeSend.disabled = true;
+  composeSend.textContent = 'Sending...';
+
+  chrome.runtime.sendMessage({
+    type: 'SEND_DM',
+    data: { username, subject, body },
+  }, (response) => {
+    if (chrome.runtime.lastError) {
+      showToast('Extension error', 'error');
+      composeSend.disabled = false;
+      composeSend.textContent = 'Send';
+      return;
+    }
+    if (response && response.success) {
+      showToast('DM sent to u/' + username, 'success');
+      closeCompose();
+    } else {
+      const err = (response && response.error) || 'Send failed';
+      showToast(err, 'error');
+      composeSend.disabled = false;
+      composeSend.textContent = 'Send';
+    }
+  });
+}
+
+function handleOpenOnReddit() {
+  const username = composeUsername.value.trim();
+  const subject = composeSubject.value.trim();
+  const body = composeBody.value.trim();
+
+  if (!username) { showToast('Enter a username', 'error'); return; }
+
+  const params = new URLSearchParams();
+  params.set('to', username);
+  if (subject) params.set('subject', subject);
+  if (body) params.set('message', body);
+
+  chrome.tabs.create({
+    url: 'https://www.reddit.com/message/compose/?' + params.toString(),
+  });
+  closeCompose();
+}
+
+// ---- Toast ----
+
+let toastTimer = null;
+function showToast(message, type) {
+  toast.textContent = message;
+  toast.className = 'toast show ' + (type || '');
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => {
+    toast.className = 'toast';
+  }, 3000);
+}
+
+// ---- Helpers ----
+
+function escapeHtml(str) {
+  if (!str) return '';
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function truncate(str, maxLen) {
+  if (!str) return '';
+  return str.length > maxLen ? str.substring(0, maxLen) + '...' : str;
+}
+
+function relativeTime(timestamp) {
+  if (!timestamp) return '';
+  const diff = Date.now() - timestamp;
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return 'now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return minutes + 'm';
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return hours + 'h';
+  const days = Math.floor(hours / 24);
+  if (days < 30) return days + 'd';
+  const months = Math.floor(days / 30);
+  return months + 'mo';
+}


### PR DESCRIPTION
## Summary
- **Replaced broken iframe** that showed "reddit.com refused to connect" with a fully native dark-themed side panel UI
- **Added activity hub** with status header (green/red login dot), stats bar (Chats/Sent/Replies counts), and tabbed interface (Conversations + Activity log)
- **Conversation list** shows all tracked users with status badges (Sent/Replied/New), message previews, search filtering, and click-to-open Reddit profile
- **Quick compose modal** (FAB button) lets users send DMs directly or open Reddit compose page, with toast notifications for feedback
- **Activity logging** in background.js records scan completions, DM sends/failures, and login status changes (capped at 50 entries)
- **Real-time updates** via `chrome.storage.onChanged` — no manual refresh needed

## Test plan
- [ ] Open side panel via extension icon — verify native UI renders (no iframe/refused-to-connect error)
- [ ] Verify green status dot when logged into Reddit, red when not
- [ ] Check stats row shows correct Chats/Sent/Replies counts matching storage data
- [ ] Verify conversation list populates with usernames, badges, and message previews
- [ ] Test search input filters conversations by username
- [ ] Click a username — should open Reddit profile in new tab
- [ ] Right-click or Ctrl+click a username — should open compose modal pre-filled
- [ ] Click FAB (+) button — compose modal opens with empty fields
- [ ] Fill compose form and click "Send" — DM sends via background.js
- [ ] Click "Open on Reddit" — opens Reddit compose page in new tab
- [ ] Switch to Activity tab — verify scan/send events appear with timestamps
- [ ] Trigger a scan or send — verify UI updates in real-time without refresh
- [ ] Check no console errors in side panel or background script

🤖 Generated with [Claude Code](https://claude.com/claude-code)