### PR TITLE
Add cancel button to onboarding sidebar

### DIFF
--- a/app/src/app/onboarding/page.tsx
+++ b/app/src/app/onboarding/page.tsx
@@ -202,7 +202,7 @@ export default function OnboardingPage() {
 
   return (
     <div className="flex h-screen bg-background">
-      <OnboardingSidebar currentStep={step} />
+      <OnboardingSidebar currentStep={step} onCancel={() => router.push('/projects')} />
 
       <main className="flex flex-1 items-center justify-center overflow-y-auto p-8">
         <AnimatePresence mode="wait" custom={directionRef.current}>

--- a/app/src/app/projects/new/page.tsx
+++ b/app/src/app/projects/new/page.tsx
@@ -197,7 +197,7 @@ export default function NewProjectPage() {
 
   return (
     <div className="flex h-screen bg-background">
-      <OnboardingSidebar currentStep={step} steps={NEW_PROJECT_STEPS} />
+      <OnboardingSidebar currentStep={step} steps={NEW_PROJECT_STEPS} onCancel={() => router.push('/projects')} />
 
       <main className="flex flex-1 items-center justify-center overflow-y-auto p-8">
         <AnimatePresence mode="wait" custom={directionRef.current}>

--- a/app/src/components/onboarding/OnboardingSidebar.tsx
+++ b/app/src/components/onboarding/OnboardingSidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Check } from 'lucide-react';
+import { Check, X } from 'lucide-react';
 import { motion } from 'motion/react';
 
 const DEFAULT_STEPS = [
@@ -13,9 +13,10 @@ const DEFAULT_STEPS = [
 interface OnboardingSidebarProps {
   currentStep: number;
   steps?: { label: string }[];
+  onCancel?: () => void;
 }
 
-export function OnboardingSidebar({ currentStep, steps = DEFAULT_STEPS }: OnboardingSidebarProps) {
+export function OnboardingSidebar({ currentStep, steps = DEFAULT_STEPS, onCancel }: OnboardingSidebarProps) {
   return (
     <div className="flex w-60 flex-col justify-between border-r bg-card p-8">
       <div>
@@ -76,9 +77,20 @@ export function OnboardingSidebar({ currentStep, steps = DEFAULT_STEPS }: Onboar
         </nav>
       </div>
 
-      <p className="text-xs text-muted-foreground/50">
-        You can always change these settings later.
-      </p>
+      <div className="space-y-3">
+        <p className="text-xs text-muted-foreground/50">
+          You can always change these settings later.
+        </p>
+        {onCancel && (
+          <button
+            onClick={onCancel}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+          >
+            <X className="h-3 w-3" />
+            Cancel
+          </button>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Added a "Cancel" button to the bottom of the onboarding sidebar (below the helper text)
- Navigates to `/projects` in both the initial onboarding and new project creation flows
- Styled as a subtle, low-emphasis link (`X` icon + "Cancel" text) so it doesn't compete with the main flow

## Test plan
- [ ] Open initial onboarding (`/onboarding`) — verify Cancel button appears at bottom of sidebar
- [ ] Click Cancel — should navigate to `/projects`
- [ ] Open new project flow (`/projects/new`) — verify Cancel button appears
- [ ] Click Cancel — should navigate to `/projects`

🤖 Generated with [Claude Code](https://claude.com/claude-code)