### PR TITLE
Make onboarding cancel button more visible

### DIFF
--- a/app/src/components/onboarding/OnboardingSidebar.tsx
+++ b/app/src/components/onboarding/OnboardingSidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Check, X } from 'lucide-react';
+import { ArrowLeft, Check } from 'lucide-react';
 import { motion } from 'motion/react';
 
 const DEFAULT_STEPS = [
@@ -77,19 +77,19 @@ export function OnboardingSidebar({ currentStep, steps = DEFAULT_STEPS, onCancel
         </nav>
       </div>
 
-      <div className="space-y-3">
-        <p className="text-xs text-muted-foreground/50">
-          You can always change these settings later.
-        </p>
+      <div className="space-y-4">
         {onCancel && (
           <button
             onClick={onCancel}
-            className="flex items-center gap-1.5 text-xs text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+            className="flex w-full items-center justify-center gap-2 rounded-lg border border-muted-foreground/20 px-4 py-2.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
           >
-            <X className="h-3 w-3" />
-            Cancel
+            <ArrowLeft className="h-4 w-4" />
+            Back to Projects
           </button>
         )}
+        <p className="text-xs text-muted-foreground/50">
+          You can always change these settings later.
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replaced the subtle `X Cancel` link with a full-width bordered button reading "Back to Projects" with an arrow icon
- Moved the button above the helper text so it's the first thing in the sidebar footer
- Much easier to spot and understand at a glance

## Test plan
- [ ] Open `/onboarding` — verify "Back to Projects" button is clearly visible at bottom of sidebar
- [ ] Open `/projects/new` — same check
- [ ] Click the button — navigates to `/projects`
- [ ] Button has hover state (background highlights)

🤖 Generated with [Claude Code](https://claude.com/claude-code)