### PR TITLE
Fix activity heatmap by persisting chat messages

### DIFF
--- a/app/src/app/api/ai/chat/route.ts
+++ b/app/src/app/api/ai/chat/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { getAnthropicClient, AI_MODEL, MAX_TOKENS } from '@/lib/ai/client';
 import { buildChatSystemPrompt } from '@/lib/ai/prompts';
+import { createClient } from '@/lib/supabase/server';
 
 export async function POST(request: NextRequest) {
   try {
@@ -12,6 +13,21 @@ export async function POST(request: NextRequest) {
         status: 400,
         headers: { 'Content-Type': 'application/json' },
       });
+    }
+
+    const projectId = project?.id;
+
+    // Persist the latest user message to chat_messages
+    if (projectId) {
+      const lastUserMsg = [...messages].reverse().find((m: { role: string }) => m.role === 'user');
+      if (lastUserMsg) {
+        const supabase = await createClient();
+        await supabase.from('chat_messages').insert({
+          project_id: projectId,
+          role: 'user',
+          content: lastUserMsg.content,
+        });
+      }
     }
 
     const client = getAnthropicClient();
@@ -55,6 +71,7 @@ export async function POST(request: NextRequest) {
 
     // Return streaming response
     const encoder = new TextEncoder();
+    let accumulated = '';
     const readableStream = new ReadableStream({
       async start(controller) {
         try {
@@ -63,6 +80,7 @@ export async function POST(request: NextRequest) {
               event.type === 'content_block_delta' &&
               event.delta.type === 'text_delta'
             ) {
+              accumulated += event.delta.text;
               controller.enqueue(
                 encoder.encode(`data: ${JSON.stringify({ text: event.delta.text })}\n\n`)
               );
@@ -70,6 +88,16 @@ export async function POST(request: NextRequest) {
           }
           controller.enqueue(encoder.encode('data: [DONE]\n\n'));
           controller.close();
+
+          // Persist the assistant response after stream completes
+          if (projectId && accumulated) {
+            const supabase = await createClient();
+            await supabase.from('chat_messages').insert({
+              project_id: projectId,
+              role: 'assistant',
+              content: accumulated,
+            });
+          }
         } catch (error) {
           controller.enqueue(
             encoder.encode(

--- a/app/src/components/chat/ChatInterface.tsx
+++ b/app/src/components/chat/ChatInterface.tsx
@@ -293,6 +293,7 @@ export function ChatInterface({
           })),
           project: project
             ? {
+                id: project.id,
                 name: project.name,
                 productName: project.product_name,
                 productDescription: project.product_description,


### PR DESCRIPTION
## Summary
- The `chat_messages` table existed in the schema but was never written to — the AI chat API streamed responses without persisting anything
- Now the `/api/ai/chat` route saves the user message before streaming and the assistant response after the stream completes
- Added `project.id` to the request body sent from `ChatInterface` so the API knows which project to save messages under
- Both the standalone chat page and the AI writer's chat persist messages, so both contribute to the activity heatmap

## Test plan
- [ ] Open a project's AI Chat page and send a message
- [ ] Check Supabase `chat_messages` table — should have new rows with `role: 'user'` and `role: 'assistant'`
- [ ] Navigate to the project dashboard — activity heatmap should show today's square colored
- [ ] Use the AI Writer chat panel — same persistence should work
- [ ] Verify hover tooltip shows correct activity count

🤖 Generated with [Claude Code](https://claude.com/claude-code)