### PR TITLE
Fix activity heatmap not showing current week

### DIFF
--- a/app/src/components/dashboard/ActivityHeatmap.tsx
+++ b/app/src/components/dashboard/ActivityHeatmap.tsx
@@ -46,12 +46,12 @@ export function ActivityHeatmap({ activityDays }: ActivityHeatmapProps) {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
-    // Find the start: go back WEEKS * 7 days, then align to Sunday
+    // Start from 52 weeks before this week's Sunday, so today is always included
     const start = new Date(today);
-    start.setDate(start.getDate() - (WEEKS * 7 - 1) - today.getDay());
+    start.setDate(today.getDate() - today.getDay() - (WEEKS * 7));
 
-    // Build cells
-    const totalDays = WEEKS * 7;
+    // Days from start through today (inclusive)
+    const totalDays = Math.round((today.getTime() - start.getTime()) / 86400000) + 1;
     const cellList: { date: Date; dateKey: string; count: number; col: number; row: number }[] = [];
     const monthSet = new Map<string, number>(); // month label → column index
 


### PR DESCRIPTION
## Summary
- The heatmap grid's start date formula had an off-by-`today.getDay()` error, causing the grid to end before the current day
- Today's activity correctly updated the streak counter but had no visible cell in the grid
- Fixed the start calculation to begin 52 weeks before the current week's Sunday, so the grid always includes today (like GitHub's contribution graph)

## Test plan
- [ ] Open dashboard — verify today's cell is visible at the far right of the heatmap
- [ ] Send a chat message, return to dashboard — today's cell should be colored orange
- [ ] Hover over today's cell — tooltip should show the correct activity count
- [ ] Verify month labels still align correctly
- [ ] Check that streak counter and grid coloring agree

🤖 Generated with [Claude Code](https://claude.com/claude-code)