### PR TITLE
Add pipeline subreddit filters

### DIFF
--- a/app/src/app/projects/[id]/dms/pipeline/page.tsx
+++ b/app/src/app/projects/[id]/dms/pipeline/page.tsx
@@ -54,6 +54,11 @@ export default function DmPipelinePage() {
   const [sortBy, setSortBy] = useState<SortOption>('newest');
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
+  // Subreddit filter state
+  const [trackedSubreddits, setTrackedSubreddits] = useState<string[]>([]);
+  const [selectedSubreddits, setSelectedSubreddits] = useState<Set<string>>(new Set());
+  const subredditPersistTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const [expandedColumn, setExpandedColumn] = useState<KanbanStage | null>(null);
   const [conversationDmId, setConversationDmId] = useState<string | null>(null);
   const [sendQueueActive, setSendQueueActive] = useState(false);
@@ -142,6 +147,89 @@ export default function DmPipelinePage() {
       await fetchMonitoredPosts();
     } catch { /* silent */ }
   }, [project.id, fetchMonitoredPosts]);
+
+  // Fetch filter preferences from config
+  const fetchFilterPreferences = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/outreach/config?project_id=${project.id}`);
+      const json = await res.json();
+      return (json.config?.pipeline_subreddit_filters as string[] | null) ?? null;
+    } catch {
+      return null;
+    }
+  }, [project.id]);
+
+  // Derive tracked subreddits from monitored posts + monitored subs, apply saved prefs
+  useEffect(() => {
+    if (loading) return;
+
+    // Derive unique subreddits from monitoredPosts (these are what actually show in pipeline)
+    const fromPosts = new Set(monitoredPosts.map((mp) => mp.subreddit.toLowerCase()));
+
+    // Also fetch from monitored_subs table as additional source
+    (async () => {
+      try {
+        const subsRes = await fetch(`/api/outreach/monitored-subs?project_id=${project.id}`);
+        const subsJson = await subsRes.json();
+        const fromSubs: string[] = (subsJson.subs || [])
+          .filter((s: { is_active?: boolean | null }) => s.is_active !== false)
+          .map((s: { name: string }) => s.name.toLowerCase());
+        for (const s of fromSubs) fromPosts.add(s);
+      } catch { /* silent */ }
+
+      const allTracked = Array.from(fromPosts).sort();
+      if (allTracked.length === 0) return;
+
+      setTrackedSubreddits(allTracked);
+
+      // Apply saved filter preferences
+      const saved = await fetchFilterPreferences();
+      if (saved && Array.isArray(saved)) {
+        const valid = new Set(saved.filter((s) => allTracked.includes(s.toLowerCase())).map((s) => s.toLowerCase()));
+        setSelectedSubreddits(valid.size > 0 ? valid : new Set(allTracked));
+      } else {
+        setSelectedSubreddits(new Set(allTracked));
+      }
+    })();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, monitoredPosts, project.id, fetchFilterPreferences]);
+
+  // Persist subreddit filter selections (debounced)
+  const persistSubredditFilters = useCallback((selected: Set<string>, tracked: string[]) => {
+    if (subredditPersistTimer.current) clearTimeout(subredditPersistTimer.current);
+    subredditPersistTimer.current = setTimeout(async () => {
+      const value = selected.size === tracked.length ? null : Array.from(selected);
+      try {
+        await fetch('/api/outreach/config', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ project_id: project.id, pipeline_subreddit_filters: value }),
+        });
+      } catch { /* silent */ }
+    }, 500);
+  }, [project.id]);
+
+  const handleToggleSubreddit = useCallback((sub: string) => {
+    setSelectedSubreddits((prev) => {
+      const next = new Set(prev);
+      if (next.has(sub)) next.delete(sub);
+      else next.add(sub);
+      persistSubredditFilters(next, trackedSubreddits);
+      return next;
+    });
+  }, [trackedSubreddits, persistSubredditFilters]);
+
+  const handleSelectAllSubreddits = useCallback(() => {
+    const all = new Set(trackedSubreddits);
+    setSelectedSubreddits(all);
+    persistSubredditFilters(all, trackedSubreddits);
+  }, [trackedSubreddits, persistSubredditFilters]);
+
+  const handleDeselectAllSubreddits = useCallback(() => {
+    const none = new Set<string>();
+    setSelectedSubreddits(none);
+    persistSubredditFilters(none, trackedSubreddits);
+  }, [trackedSubreddits, persistSubredditFilters]);
 
   // Initial data load
   useEffect(() => {
@@ -375,8 +463,13 @@ export default function DmPipelinePage() {
       dmsByPermalink.set(key, arr);
     }
 
+    // Filter to only tracked subreddits (if any tracked)
+    const filteredMonitoredPosts = trackedSubreddits.length > 0
+      ? monitoredPosts.filter((mp) => trackedSubreddits.includes(mp.subreddit.toLowerCase()))
+      : monitoredPosts;
+
     // Map monitored posts → PostInfo (even 0-lead posts)
-    return monitoredPosts.map((mp) => {
+    return filteredMonitoredPosts.map((mp) => {
       const key = normalizePermalink(mp.permalink);
       const dms = dmsByPermalink.get(key) || [];
 
@@ -404,7 +497,7 @@ export default function DmPipelinePage() {
         stages,
       };
     }).sort((a, b) => b.leadsCount - a.leadsCount);
-  }, [monitoredPosts, allDms]);
+  }, [monitoredPosts, allDms, trackedSubreddits]);
 
   // Column mapping
   const columns = useMemo(() => {
@@ -412,6 +505,7 @@ export default function DmPipelinePage() {
 
     // Filter by selected post (permalink match)
     if (selectedPostId) {
+      // When a specific post is selected, show all leads from that post (no subreddit filter)
       const selectedPost = postInfos.find((p) => p.postId === selectedPostId);
       if (selectedPost) {
         const selectedPermalink = normalizePermalink(selectedPost.permalink);
@@ -419,6 +513,14 @@ export default function DmPipelinePage() {
           (d) => normalizePermalink(d.source_thread_permalink) === selectedPermalink
         );
       }
+    } else if (trackedSubreddits.length > 0) {
+      // "All Posts" mode — filter by selected subreddits
+      filtered = filtered.filter((d) => {
+        const permalink = d.source_thread_permalink;
+        const match = permalink.match(/\/r\/([^/]+)\//);
+        if (!match) return false; // chat:// or malformed — filter out
+        return selectedSubreddits.has(match[1].toLowerCase());
+      });
     }
 
     // Search filter
@@ -440,7 +542,17 @@ export default function DmPipelinePage() {
       followup: sorted.filter((d) => d.pipeline_stage === 'responded'),
       converted: sorted.filter((d) => d.pipeline_stage === 'converted'),
     };
-  }, [allDms, selectedPostId, searchQuery, sortBy, postInfos]);
+  }, [allDms, selectedPostId, searchQuery, sortBy, postInfos, trackedSubreddits, selectedSubreddits]);
+
+  // Lead count for filtered "All Posts" view
+  const filteredLeadCount = useMemo(() => {
+    if (trackedSubreddits.length === 0) return allDms.length;
+    return allDms.filter((d) => {
+      const match = d.source_thread_permalink.match(/\/r\/([^/]+)\//);
+      if (!match) return false;
+      return selectedSubreddits.has(match[1].toLowerCase());
+    }).length;
+  }, [allDms, trackedSubreddits, selectedSubreddits]);
 
   // Selection handlers
   function handleSelect(id: string) {
@@ -521,6 +633,12 @@ export default function DmPipelinePage() {
               allDms={allDms}
               selectedPostId={selectedPostId}
               onSelectPost={setSelectedPostId}
+              trackedSubreddits={trackedSubreddits}
+              selectedSubreddits={selectedSubreddits}
+              onToggleSubreddit={handleToggleSubreddit}
+              onSelectAllSubreddits={handleSelectAllSubreddits}
+              onDeselectAllSubreddits={handleDeselectAllSubreddits}
+              filteredLeadCount={filteredLeadCount}
             />
 
             {/* Reddit Bridge status */}

--- a/app/src/components/pipeline/PostFilterRow.tsx
+++ b/app/src/components/pipeline/PostFilterRow.tsx
@@ -3,6 +3,7 @@
 import { MessageSquare, ArrowUp, ImageIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
+import { SubredditFilterPopover } from './SubredditFilterPopover';
 import type { OutreachDM } from '@/types';
 
 interface PostInfo {
@@ -23,6 +24,12 @@ interface PostFilterRowProps {
   allDms: OutreachDM[];
   selectedPostId: string | null;
   onSelectPost: (postId: string | null) => void;
+  trackedSubreddits: string[];
+  selectedSubreddits: Set<string>;
+  onToggleSubreddit: (sub: string) => void;
+  onSelectAllSubreddits: () => void;
+  onDeselectAllSubreddits: () => void;
+  filteredLeadCount: number;
 }
 
 function getSubredditColor(sub: string): string {
@@ -56,8 +63,21 @@ function PipelineStrip({ stages }: { stages: PostInfo['stages'] }) {
   );
 }
 
-export function PostFilterRow({ posts, allDms, selectedPostId, onSelectPost }: PostFilterRowProps) {
+export function PostFilterRow({
+  posts,
+  allDms,
+  selectedPostId,
+  onSelectPost,
+  trackedSubreddits,
+  selectedSubreddits,
+  onToggleSubreddit,
+  onSelectAllSubreddits,
+  onDeselectAllSubreddits,
+  filteredLeadCount,
+}: PostFilterRowProps) {
   const totalLeads = allDms.length;
+  const hasSubredditFilter = trackedSubreddits.length > 0;
+  const isFiltered = hasSubredditFilter && selectedSubreddits.size < trackedSubreddits.length;
 
   return (
     <div className="space-y-2">
@@ -84,8 +104,23 @@ export function PostFilterRow({ posts, allDms, selectedPostId, onSelectPost }: P
           >
             <span className="text-lg opacity-60 mb-1">&#9783;</span>
             <span className="text-xs font-bold">All Posts</span>
-            <span className="text-xl font-extrabold text-primary mt-0.5">{totalLeads}</span>
-            <span className="text-[10px] text-muted-foreground">total leads</span>
+            <span className="text-xl font-extrabold text-primary mt-0.5">
+              {isFiltered ? filteredLeadCount : totalLeads}
+            </span>
+            <span className="text-[10px] text-muted-foreground">
+              {isFiltered ? `of ${totalLeads} leads` : 'total leads'}
+            </span>
+            {hasSubredditFilter && (
+              <div className="mt-1">
+                <SubredditFilterPopover
+                  trackedSubreddits={trackedSubreddits}
+                  selectedSubreddits={selectedSubreddits}
+                  onToggle={onToggleSubreddit}
+                  onSelectAll={onSelectAllSubreddits}
+                  onDeselectAll={onDeselectAllSubreddits}
+                />
+              </div>
+            )}
           </button>
 
           {/* Empty state hint */}
@@ -97,8 +132,8 @@ export function PostFilterRow({ posts, allDms, selectedPostId, onSelectPost }: P
             </div>
           )}
 
-          {/* Individual post cards */}
-          {posts.map((post) => (
+          {/* Individual post cards (filtered by selected subreddits) */}
+          {posts.filter((post) => !hasSubredditFilter || selectedSubreddits.has(post.subreddit.toLowerCase())).map((post) => (
             <button
               key={post.postId}
               onClick={() => onSelectPost(post.postId)}

--- a/app/src/components/pipeline/SubredditFilterPopover.tsx
+++ b/app/src/components/pipeline/SubredditFilterPopover.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { Filter } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from '@/components/ui/popover';
+
+function getSubredditColor(sub: string): string {
+  const colors = [
+    'bg-purple-500', 'bg-orange-500', 'bg-cyan-500', 'bg-blue-500',
+    'bg-pink-500', 'bg-green-500', 'bg-red-500', 'bg-yellow-500',
+  ];
+  let hash = 0;
+  for (let i = 0; i < sub.length; i++) hash = sub.charCodeAt(i) + ((hash << 5) - hash);
+  return colors[Math.abs(hash) % colors.length];
+}
+
+interface SubredditFilterPopoverProps {
+  trackedSubreddits: string[];
+  selectedSubreddits: Set<string>;
+  onToggle: (sub: string) => void;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+}
+
+export function SubredditFilterPopover({
+  trackedSubreddits,
+  selectedSubreddits,
+  onToggle,
+  onSelectAll,
+  onDeselectAll,
+}: SubredditFilterPopoverProps) {
+  const allSelected = selectedSubreddits.size === trackedSubreddits.length;
+  const noneSelected = selectedSubreddits.size === 0;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          className={cn(
+            'inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-md transition-colors',
+            allSelected
+              ? 'text-muted-foreground hover:bg-muted'
+              : 'text-primary bg-primary/10 hover:bg-primary/15'
+          )}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Filter className="h-3 w-3" />
+          {allSelected ? 'Filter' : `${selectedSubreddits.size}/${trackedSubreddits.length}`}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={8}
+        className="w-56 p-0"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-3 py-2 border-b flex items-center justify-between">
+          <span className="text-xs font-semibold">Filter Subreddits</span>
+          <div className="flex gap-1.5">
+            <button
+              onClick={onSelectAll}
+              disabled={allSelected}
+              className="text-[10px] font-medium text-primary hover:underline disabled:opacity-40 disabled:no-underline"
+            >
+              All
+            </button>
+            <span className="text-muted-foreground text-[10px]">/</span>
+            <button
+              onClick={onDeselectAll}
+              disabled={noneSelected}
+              className="text-[10px] font-medium text-primary hover:underline disabled:opacity-40 disabled:no-underline"
+            >
+              None
+            </button>
+          </div>
+        </div>
+        <div className="max-h-48 overflow-y-auto py-1">
+          {trackedSubreddits.map((sub) => {
+            const checked = selectedSubreddits.has(sub);
+            return (
+              <button
+                key={sub}
+                onClick={() => onToggle(sub)}
+                className="flex items-center gap-2 w-full px-3 py-1.5 text-left hover:bg-muted/50 transition-colors"
+              >
+                <div
+                  className={cn(
+                    'h-3.5 w-3.5 rounded border flex items-center justify-center shrink-0 transition-colors',
+                    checked
+                      ? 'bg-primary border-primary'
+                      : 'border-muted-foreground/30'
+                  )}
+                >
+                  {checked && (
+                    <svg className="h-2.5 w-2.5 text-primary-foreground" viewBox="0 0 12 12" fill="none">
+                      <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  )}
+                </div>
+                <div className={cn('w-2.5 h-2.5 rounded-full shrink-0', getSubredditColor(sub))} />
+                <span className="text-xs truncate">r/{sub}</span>
+              </button>
+            );
+          })}
+        </div>
+        {noneSelected && (
+          <div className="px-3 py-2 border-t">
+            <p className="text-[10px] text-muted-foreground">Select at least one subreddit to see leads.</p>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -280,6 +280,7 @@ export interface OutreachConfig {
   customer_goals: string[];
   target_activities: string[];
   scan_wizard_completed: boolean;
+  pipeline_subreddit_filters: string[] | null;
   created_at: string;
   updated_at: string;
 }
@@ -340,11 +341,15 @@ export interface OutreachSignal {
   buyer_intent: BuyerIntent | null;
   discovery_source: DiscoverySource | null;
   pipeline_version: number | null;
+  urgency: string | null;
+  match_reason: string | null;
 }
 
 export type LeadTier = 'hot' | 'warm' | 'cold';
 
 export type BuyerIntent = 'problem_aware' | 'solution_seeking' | 'comparing' | 'ready_to_buy';
+
+export type Urgency = 'none' | 'low' | 'medium' | 'high';
 
 export type DiscoverySource = 'subreddit_browse' | 'keyword_search' | 'comment_search' | 'both';
 

--- a/app/supabase/migrations/017_pipeline_subreddit_filters.sql
+++ b/app/supabase/migrations/017_pipeline_subreddit_filters.sql
@@ -1,0 +1,4 @@
+-- Add pipeline subreddit filter preferences to outreach_configs
+-- NULL = all selected (default). When set, it's a string[] of selected subreddit names.
+ALTER TABLE outreach_configs
+ADD COLUMN IF NOT EXISTS pipeline_subreddit_filters JSONB DEFAULT NULL;


### PR DESCRIPTION
## Summary
- Add subreddit multi-select filter popover on the "All Posts" card to scope the Kanban board to tracked subreddits
- PostFilterRow now only shows post cards from selected subreddits, with filtered lead counts
- Pipeline page derives tracked subs from monitored posts + monitored_subs table, persists selections to `outreach_configs` via debounced PATCH
- DB migration adds `pipeline_subreddit_filters` JSONB column to `outreach_configs` (NULL = all selected)

## Test plan
- [ ] Navigate to pipeline page — confirm subreddit filter popover appears on "All Posts" card
- [ ] Toggle subreddits — Kanban board and post cards update immediately
- [ ] Click a specific post card — all leads from that post shown regardless of filter
- [ ] Refresh page — filter selections persist
- [ ] Test with no tracked subreddits — all leads shown, no popover rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)