### PR TITLE
Add two-lane scan filter + intent-boosted scoring

### DIFF
--- a/app/src/app/api/outreach/signals/route.ts
+++ b/app/src/app/api/outreach/signals/route.ts
@@ -186,7 +186,8 @@ export async function GET(request: NextRequest) {
         .from('outreach_signals')
         .select('*')
         .eq('project_id', projectId)
-        .order('combined_score', { ascending: false });
+        .order('combined_score', { ascending: false })
+        .order('created_utc', { ascending: false });
 
       if (status) {
         query = query.eq('status', status);

--- a/app/src/lib/ai/prompts.ts
+++ b/app/src/lib/ai/prompts.ts
@@ -742,6 +742,15 @@ export const SIGNAL_ANALYSIS_V3_SYSTEM_PROMPT = `You are an expert Reddit lead c
 ## Decision Maker Detection
 Set decision_maker to true when the poster appears to be making the purchasing/adoption decision.
 
+## Urgency
+- **none**: No time pressure indicated
+- **low**: Vague timeline ("eventually", "sometime soon")
+- **medium**: Moderate timeline ("this quarter", "next few weeks", "soon")
+- **high**: Urgent need ("ASAP", "by Friday", "contract expiring", "need this today", "deadline")
+
+## Match Reason
+Provide a single sentence explaining WHY this post is relevant to the product. Focus on the specific problem or need that connects to the product's value proposition. This is for internal use only.
+
 ## Calibration Examples
 
 ### Fit=9, Lead=9, Auth=9, Rel=9 (ready_to_buy):
@@ -780,6 +789,8 @@ Return JSON array. Each post can have multiple signal_types.
       "signal_types": ["tool_switch", "high_signal_comment"],
       "pain_severity": "medium",
       "decision_maker": false,
+      "urgency": "medium",
+      "match_reason": "User is actively seeking a tool switch due to pricing frustration, directly matching our value proposition.",
       "competitor_mentions": [
         { "name": "CompetitorX", "sentiment": "negative", "switching_intent": true, "context": "frustrated with pricing" }
       ]
@@ -837,7 +848,7 @@ ${weaknessesSection}
 ## Posts to Classify
 ${postList}
 
-Score each post on Fit (1-10), Lead (1-10), Authenticity (1-10), and Relevance (1-10). Also determine the buyer intent stage for each post.`;
+Score each post on Fit (1-10), Lead (1-10), Authenticity (1-10), and Relevance (1-10). Also determine the buyer intent stage, urgency level, and match reason for each post.`;
 }
 
 // ---- Outreach: Signal Analysis (7-type classification) ----

--- a/app/src/lib/outreach/detector.ts
+++ b/app/src/lib/outreach/detector.ts
@@ -7,7 +7,7 @@
  */
 
 import { searchMultiSubPosts, fetchSubredditPosts } from '@/lib/reddit/fetcher';
-import { tier1Score, findCompetitorMentions } from '@/lib/outreach/signal-patterns';
+import { tier1Score, findCompetitorMentions, heuristicPreFilter } from '@/lib/outreach/signal-patterns';
 import {
   classifyPostsRealtime,
   reclassifyWithSonnet,
@@ -19,7 +19,7 @@ import {
   type ClassificationResultV2,
   type ClassificationResultV3,
 } from '@/lib/outreach/signal-classifier';
-import { computeEnhancedScore, computeV2CombinedScore, deriveLeadTier, computeV3CombinedScore, deriveLeadTierV3 } from '@/lib/outreach/scoring';
+import { computeEnhancedScore, computeV2CombinedScore, deriveLeadTier, computeV3CombinedScore, deriveLeadTierV3, computeV3CombinedScoreEnhanced, deriveLeadTierV3Enhanced } from '@/lib/outreach/scoring';
 import * as pullpush from '@/lib/reddit/pullpush';
 import { buildCacheKey, getCachedSearch, setCachedSearch } from '@/lib/reddit/cache';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -502,10 +502,12 @@ const V3_CLASSIFY_BATCH_SIZE = 20;
 /**
  * V3 detection pipeline:
  * 1. Browse subreddits (free) + keyword search (free)
- * 2. Deduplicate against DB
- * 3. AI pre-filter on titles (replaces regex)
- * 4. Full 4-dimension AI classification
- * 5. Build signal rows with V3 scoring
+ * 2. Deduplicate against DB (only process new posts)
+ * 3. Two-lane pre-filter:
+ *    - Fast lane: heuristic keyword/competitor/regex match (free, instant)
+ *    - Semantic lane: AI title screening for remaining posts (cheap, batched)
+ * 4. Full 4-dimension AI classification on filtered posts
+ * 5. Intent-boosted scoring (buyer_intent, urgency, pain, competitor switching)
  */
 export async function detectSignalsV3(
   supabase: SupabaseClient,
@@ -674,40 +676,60 @@ export async function detectSignalsV3(
 
   if (newPosts.length === 0) return 0;
 
-  // ---- AI Pre-Filter (replaces regex Tier 1) ----
-  let filteredPosts = newPosts;
+  // ---- Two-Lane Pre-Filter: Heuristic Fast-Pass + AI Semantic Filter ----
+  // Lane 1 (free): Posts matching keywords/competitors/regex skip straight to classification
+  // Lane 2 (cheap): Remaining posts get AI title screening for semantic relevance
+  const fastPassPosts: typeof newPosts = [];
+  const needsAIFilter: typeof newPosts = [];
 
-  try {
-    // Batch titles into groups of 50
-    const titleBatches: { index: number; title: string }[][] = [];
-    for (let i = 0; i < newPosts.length; i += PRE_FILTER_BATCH_SIZE) {
-      titleBatches.push(
-        newPosts.slice(i, i + PRE_FILTER_BATCH_SIZE).map((p, j) => ({
-          index: i + j,
-          title: p.title || p.selftext?.slice(0, 100) || '',
-        }))
-      );
+  for (const p of newPosts) {
+    const result = heuristicPreFilter(p.title, p.selftext, keywords, competitors);
+    if (result.passed) {
+      fastPassPosts.push(p);
+    } else {
+      needsAIFilter.push(p);
     }
-
-    const passedIndices = new Set<number>();
-    for (const batch of titleBatches) {
-      const indices = await preFilterPosts(batch, { productName, productDescription });
-      for (const idx of indices) {
-        passedIndices.add(idx);
-      }
-    }
-
-    filteredPosts = newPosts.filter((_, i) => passedIndices.has(i));
-    console.log('[DetectorV3] Pre-filter passed:', filteredPosts.length, '/', newPosts.length);
-  } catch (preFilterErr) {
-    // Fall back to regex tier1 scoring if AI pre-filter fails
-    console.warn('[DetectorV3] Pre-filter failed, falling back to regex:', (preFilterErr as Error).message);
-    filteredPosts = newPosts.filter((p) => {
-      const t1 = tier1Score(p.title, p.selftext);
-      return t1.score >= TIER1_THRESHOLD;
-    });
-    console.log('[DetectorV3] Regex fallback passed:', filteredPosts.length);
   }
+
+  console.log('[DetectorV3] Heuristic fast-pass:', fastPassPosts.length, '| Needs AI filter:', needsAIFilter.length);
+
+  // AI semantic pre-filter on posts that didn't match heuristics
+  const aiPassedPosts: typeof newPosts = [];
+  if (needsAIFilter.length > 0) {
+    try {
+      const titleBatches: { index: number; title: string }[][] = [];
+      for (let i = 0; i < needsAIFilter.length; i += PRE_FILTER_BATCH_SIZE) {
+        titleBatches.push(
+          needsAIFilter.slice(i, i + PRE_FILTER_BATCH_SIZE).map((p, j) => ({
+            index: i + j,
+            title: p.title || p.selftext?.slice(0, 100) || '',
+          }))
+        );
+      }
+
+      const passedIndices = new Set<number>();
+      for (const batch of titleBatches) {
+        const indices = await preFilterPosts(batch, { productName, productDescription });
+        for (const idx of indices) {
+          passedIndices.add(idx);
+        }
+      }
+
+      for (const idx of passedIndices) {
+        if (idx < needsAIFilter.length) {
+          aiPassedPosts.push(needsAIFilter[idx]);
+        }
+      }
+      console.log('[DetectorV3] AI semantic filter passed:', aiPassedPosts.length, '/', needsAIFilter.length);
+    } catch (preFilterErr) {
+      // AI pre-filter failed — these posts are simply skipped (fast-pass posts still proceed)
+      console.warn('[DetectorV3] AI pre-filter failed, skipping semantic lane:', (preFilterErr as Error).message);
+    }
+  }
+
+  // Merge both lanes
+  const filteredPosts = [...fastPassPosts, ...aiPassedPosts];
+  console.log('[DetectorV3] Total posts for classification:', filteredPosts.length, '/', newPosts.length);
 
   if (filteredPosts.length === 0) return 0;
 
@@ -753,18 +775,44 @@ export async function detectSignalsV3(
     const v3 = v3Classifications.get(post.id);
     const postSource = (post as { _source?: string })._source || 'keyword_search';
 
-    let fitScore = v3?.fit_score ?? 5;
-    let leadScore = v3?.lead_score ?? 3;
-    let authenticityScore = v3?.authenticity_score ?? 5;
-    let relevanceScore = v3?.relevance_score ?? 5;
-    let buyerIntent = v3?.buyer_intent ?? 'problem_aware';
-    let intentType = v3?.intent_type ?? 'discussion';
-    let signalTypes = v3?.signal_types ?? [];
-    let painSeverity = v3?.pain_severity ?? null;
-    let decisionMaker = v3?.decision_maker ?? false;
+    const fitScore = v3?.fit_score ?? 5;
+    const leadScore = v3?.lead_score ?? 3;
+    const authenticityScore = v3?.authenticity_score ?? 5;
+    const relevanceScore = v3?.relevance_score ?? 5;
+    const buyerIntent = v3?.buyer_intent ?? 'problem_aware';
+    const intentType = v3?.intent_type ?? 'discussion';
+    const signalTypes = v3?.signal_types ?? [];
+    const painSeverity = v3?.pain_severity ?? null;
+    const decisionMaker = v3?.decision_maker ?? false;
+    const urgency = v3?.urgency ?? 'none';
+    const matchReason = v3?.match_reason ?? null;
 
-    const combinedScore = computeV3CombinedScore(fitScore, leadScore, authenticityScore, relevanceScore);
-    const leadTier = deriveLeadTierV3(fitScore, leadScore, authenticityScore, relevanceScore);
+    const competitorMentioned = (v3?.competitor_mentions?.length ?? 0) > 0;
+    const switchingIntent = v3?.competitor_mentions?.some((c) => c.switching_intent) ?? false;
+
+    const combinedScore = computeV3CombinedScoreEnhanced({
+      fit: fitScore,
+      lead: leadScore,
+      authenticity: authenticityScore,
+      relevance: relevanceScore,
+      buyerIntent,
+      decisionMaker,
+      painSeverity,
+      competitorMentioned,
+      switchingIntent,
+      urgency: urgency as 'none' | 'low' | 'medium' | 'high',
+    });
+    const leadTier = deriveLeadTierV3Enhanced({
+      fit: fitScore,
+      lead: leadScore,
+      authenticity: authenticityScore,
+      relevance: relevanceScore,
+      buyerIntent,
+      decisionMaker,
+      painSeverity,
+      competitorMentioned,
+      switchingIntent,
+    });
 
     // Backward compat: engage_score = avg(authenticity, relevance)
     const engageScore = Math.round((authenticityScore + relevanceScore) / 2);
@@ -786,7 +834,7 @@ export async function detectSignalsV3(
       matched_keywords: keywords.filter((kw) =>
         `${post.title} ${post.selftext}`.toLowerCase().includes(kw.toLowerCase())
       ),
-      competitor_mentioned: (v3?.competitor_mentions?.length ?? 0) > 0,
+      competitor_mentioned: competitorMentioned,
       signal_types: signalTypes,
       pain_severity: painSeverity,
       decision_maker: decisionMaker,
@@ -807,6 +855,9 @@ export async function detectSignalsV3(
       buyer_intent: buyerIntent,
       discovery_source: postSource,
       pipeline_version: 3,
+      // V3 enhanced fields
+      urgency,
+      match_reason: matchReason,
     };
   });
 
@@ -817,8 +868,8 @@ export async function detectSignalsV3(
       .upsert(signals, { onConflict: 'project_id,reddit_id' });
 
     if (upsertError) {
-      // Strip V3 columns and retry with V2
-      const withoutV3 = signals.map(({ authenticity_score, relevance_score, buyer_intent, discovery_source, pipeline_version, ...rest }) => rest);
+      // Strip V3 + enhanced columns and retry with V2
+      const withoutV3 = signals.map(({ authenticity_score, relevance_score, buyer_intent, discovery_source, pipeline_version, urgency, match_reason, ...rest }) => rest);
       const { error: retryV2Error } = await supabase
         .from('outreach_signals')
         .upsert(withoutV3, { onConflict: 'project_id,reddit_id' });

--- a/app/src/lib/outreach/scoring.ts
+++ b/app/src/lib/outreach/scoring.ts
@@ -57,7 +57,7 @@ export function computeCombinedScore(
 
 // ---- V2 Scoring ----
 
-import type { LeadTier, BuyerIntent } from '@/types';
+import type { LeadTier, BuyerIntent, Urgency } from '@/types';
 
 export function computeV2CombinedScore(fitScore: number, leadScore: number, engageScore: number): number {
   return (fitScore * 0.4 + leadScore * 0.35 + engageScore * 0.25) / 10;
@@ -78,6 +78,101 @@ export function computeV3CombinedScore(fit: number, lead: number, authenticity: 
 export function deriveLeadTierV3(fit: number, lead: number, authenticity: number, relevance: number): LeadTier {
   if (fit >= 7 && lead >= 7 && authenticity >= 6 && relevance >= 5) return 'hot';
   if (fit >= 5 && lead >= 5 && authenticity >= 4) return 'warm';
+  return 'cold';
+}
+
+// ---- V3 Enhanced Scoring (intent-boosted) ----
+
+const BUYER_INTENT_BONUS: Record<BuyerIntent, number> = {
+  problem_aware: 0,
+  solution_seeking: 0.04,
+  comparing: 0.07,
+  ready_to_buy: 0.12,
+};
+
+const PAIN_SEVERITY_BONUS: Record<string, number> = {
+  low: 0,
+  medium: 0.02,
+  high: 0.05,
+};
+
+const URGENCY_BONUS: Record<Urgency, number> = {
+  none: 0,
+  low: 0.01,
+  medium: 0.03,
+  high: 0.06,
+};
+
+export function computeV3CombinedScoreEnhanced(params: {
+  fit: number;
+  lead: number;
+  authenticity: number;
+  relevance: number;
+  buyerIntent: BuyerIntent;
+  decisionMaker: boolean;
+  painSeverity: string | null;
+  competitorMentioned: boolean;
+  switchingIntent: boolean;
+  urgency?: Urgency;
+}): number {
+  const base = (params.fit * 0.30 + params.lead * 0.30 + params.authenticity * 0.20 + params.relevance * 0.20) / 10;
+
+  let bonus = 0;
+  bonus += BUYER_INTENT_BONUS[params.buyerIntent] ?? 0;
+  if (params.decisionMaker) bonus += 0.05;
+  bonus += PAIN_SEVERITY_BONUS[params.painSeverity ?? 'low'] ?? 0;
+  if (params.competitorMentioned && params.switchingIntent) bonus += 0.08;
+  bonus += URGENCY_BONUS[params.urgency ?? 'none'] ?? 0;
+
+  return Math.min(1.0, base + bonus);
+}
+
+export function deriveLeadTierV3Enhanced(params: {
+  fit: number;
+  lead: number;
+  authenticity: number;
+  relevance: number;
+  buyerIntent: BuyerIntent;
+  decisionMaker: boolean;
+  painSeverity: string | null;
+  competitorMentioned: boolean;
+  switchingIntent: boolean;
+}): LeadTier {
+  const { fit, lead, authenticity, relevance, buyerIntent, decisionMaker, painSeverity, competitorMentioned, switchingIntent } = params;
+
+  // Intent-boosted HOT: ready_to_buy/comparing + strong scores
+  if ((buyerIntent === 'ready_to_buy' || buyerIntent === 'comparing') &&
+      fit >= 5 && lead >= 6 && authenticity >= 5 && relevance >= 4) {
+    return 'hot';
+  }
+
+  // DM+pain HOT: decision maker + high pain + strong scores
+  if (decisionMaker && painSeverity === 'high' &&
+      fit >= 5 && lead >= 5 && authenticity >= 5 && relevance >= 4) {
+    return 'hot';
+  }
+
+  // Competitor switch HOT: competitor mentioned + switching intent + strong scores
+  if (competitorMentioned && switchingIntent && fit >= 5 && lead >= 5) {
+    return 'hot';
+  }
+
+  // Original HOT threshold
+  if (fit >= 7 && lead >= 7 && authenticity >= 6 && relevance >= 5) {
+    return 'hot';
+  }
+
+  // Intent-boosted WARM: solution_seeking/comparing/ready_to_buy + moderate scores
+  if ((buyerIntent === 'solution_seeking' || buyerIntent === 'comparing' || buyerIntent === 'ready_to_buy') &&
+      fit >= 4 && lead >= 4 && authenticity >= 3) {
+    return 'warm';
+  }
+
+  // Original WARM threshold
+  if (fit >= 5 && lead >= 5 && authenticity >= 4) {
+    return 'warm';
+  }
+
   return 'cold';
 }
 

--- a/app/src/lib/outreach/signal-classifier.ts
+++ b/app/src/lib/outreach/signal-classifier.ts
@@ -14,7 +14,7 @@ import {
   SIGNAL_ANALYSIS_V3_SYSTEM_PROMPT,
   buildV3ClassificationPrompt,
 } from '@/lib/ai/prompts';
-import type { SignalType, PainSeverity, ScoreBin, BuyerIntent } from '@/types';
+import type { SignalType, PainSeverity, ScoreBin, BuyerIntent, Urgency } from '@/types';
 
 export interface ClassificationInput {
   reddit_id: string;
@@ -383,10 +383,13 @@ export interface ClassificationResultV3 {
   signal_types: SignalType[];
   pain_severity: PainSeverity | null;
   decision_maker: boolean;
+  urgency: Urgency;
+  match_reason: string | null;
   competitor_mentions: { name: string; sentiment: string; switching_intent: boolean; context: string }[];
 }
 
 const VALID_BUYER_INTENTS: BuyerIntent[] = ['problem_aware', 'solution_seeking', 'comparing', 'ready_to_buy'];
+const VALID_URGENCIES: Urgency[] = ['none', 'low', 'medium', 'high'];
 
 /**
  * Pre-filter posts by title using a cheap Haiku call.
@@ -500,6 +503,8 @@ function parseV3ClassificationResponse(responseText: string): ClassificationResu
         signal_types: SignalType[];
         pain_severity: PainSeverity | null;
         decision_maker: boolean;
+        urgency?: Urgency;
+        match_reason?: string | null;
         competitor_mentions: { name: string; sentiment: string; switching_intent: boolean; context: string }[];
       }[];
     };
@@ -511,6 +516,8 @@ function parseV3ClassificationResponse(responseText: string): ClassificationResu
       authenticity_score: Math.max(1, Math.min(10, c.authenticity_score)),
       relevance_score: Math.max(1, Math.min(10, c.relevance_score)),
       buyer_intent: VALID_BUYER_INTENTS.includes(c.buyer_intent) ? c.buyer_intent : 'problem_aware',
+      urgency: VALID_URGENCIES.includes(c.urgency as Urgency) ? c.urgency! : 'none',
+      match_reason: c.match_reason ?? null,
     }));
   } catch {
     return [];

--- a/app/src/lib/outreach/signal-patterns.ts
+++ b/app/src/lib/outreach/signal-patterns.ts
@@ -148,3 +148,77 @@ export function findCompetitorMentions(
 
   return results;
 }
+
+// ---- Heuristic Pre-Filter ----
+
+export interface HeuristicResult {
+  score: number;
+  passed: boolean;
+  tier1: Tier1Result;
+  keywordMatches: string[];
+  competitorMatches: string[];
+  negativeSignals: string[];
+}
+
+const NEGATIVE_PATTERNS = [
+  { pattern: /\b(?:i\s+built|check\s+out\s+my|just\s+launched\s+my|i\s+made|i\s+created)\b/i, label: 'self_promotion' },
+  { pattern: /\b(?:meme|shitpost|shit\s*post|mod\s+post|rule\s+update|meta\s+thread)\b/i, label: 'meme_meta' },
+];
+
+const HEURISTIC_THRESHOLD = 3;
+
+/**
+ * Heuristic pre-filter: combines tier1 regex scoring, keyword matching,
+ * competitor matching, and negative signal detection.
+ * Posts scoring >= 3 pass to AI classification.
+ */
+export function heuristicPreFilter(
+  title: string,
+  body: string | null,
+  keywords: string[],
+  competitors: string[]
+): HeuristicResult {
+  const text = `${title} ${body || ''}`;
+  const textLower = text.toLowerCase();
+
+  // 1. Tier 1 regex scoring
+  const tier1 = tier1Score(title, body);
+
+  // 2. Keyword matching: +3 per keyword match
+  const keywordMatches: string[] = [];
+  for (const kw of keywords) {
+    if (kw && textLower.includes(kw.toLowerCase())) {
+      keywordMatches.push(kw);
+    }
+  }
+  const keywordBonus = keywordMatches.length * 3;
+
+  // 3. Competitor matching: +2 per competitor match
+  const competitorMentions = findCompetitorMentions(text, competitors);
+  const competitorMatches = competitorMentions.map((m) => m.name);
+  const competitorBonus = competitorMatches.length * 2;
+
+  // 4. Negative signal detection
+  const negativeSignals: string[] = [];
+  for (const { pattern, label } of NEGATIVE_PATTERNS) {
+    if (pattern.test(text)) {
+      negativeSignals.push(label);
+    }
+  }
+  // URL-only posts with no selftext and no question
+  if (!body?.trim() && /^https?:\/\//i.test(title) && !title.includes('?')) {
+    negativeSignals.push('url_only_no_engagement');
+  }
+  const negativePenalty = negativeSignals.length * 3;
+
+  const score = Math.max(0, tier1.score + keywordBonus + competitorBonus - negativePenalty);
+
+  return {
+    score,
+    passed: score >= HEURISTIC_THRESHOLD,
+    tier1,
+    keywordMatches,
+    competitorMatches,
+    negativeSignals,
+  };
+}

--- a/app/supabase/migrations/018_intent_scoring.sql
+++ b/app/supabase/migrations/018_intent_scoring.sql
@@ -1,0 +1,3 @@
+-- Add urgency and match_reason columns to outreach_signals
+ALTER TABLE outreach_signals ADD COLUMN IF NOT EXISTS urgency TEXT DEFAULT 'none';
+ALTER TABLE outreach_signals ADD COLUMN IF NOT EXISTS match_reason TEXT;


### PR DESCRIPTION
## Summary
- **Two-lane pre-filter** replaces single AI pre-filter: heuristic fast-pass (keywords/competitors/regex at $0) catches obvious matches instantly, AI semantic title filter catches posts with zero keyword overlap (e.g. "Got $350 to spend" in a TCG sub)
- **Intent-boosted scoring** adds bonuses for buyer_intent (ready_to_buy +0.12), decision_maker (+0.05), pain_severity, competitor switching (+0.08), and urgency (+0.06 for high)
- **New lead tier paths**: HOT for ready_to_buy/comparing with moderate scores, competitor switchers, and decision makers with high pain
- **Urgency + match_reason** added to V3 AI classification (none/low/medium/high urgency, 1-sentence match explanation)
- **DB migration 018**: adds `urgency` and `match_reason` columns to `outreach_signals`
- **Sorting tiebreaker**: secondary sort by `created_utc` so fresher leads win ties

## Test plan
- [ ] Apply migration 018 to Supabase
- [ ] Run "Scan Now" and verify logs show two-lane filter (heuristic fast-pass count + AI semantic filter count)
- [ ] Verify posts with user keywords pass via free heuristic lane
- [ ] Verify posts with zero keyword overlap still get caught by AI semantic lane
- [ ] Confirm `ready_to_buy`/`comparing` signals rank higher than `problem_aware` at similar raw scores
- [ ] Check `urgency` and `match_reason` populated on new signals
- [ ] Verify competitor switching signals boosted to hot tier
- [ ] TypeScript compiles: `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)