### PR TITLE
Add Discord DM alerts, async scanning, and UI fixes

### DIFF
--- a/app/src/app/api/alerts/disconnect/route.ts
+++ b/app/src/app/api/alerts/disconnect/route.ts
@@ -9,9 +9,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'project_id is required' }, { status: 400 });
     }
 
-    if (!channel || !['discord', 'slack', 'email', 'telegram'].includes(channel)) {
+    if (!channel || !['discord', 'discord_dm', 'slack', 'email', 'telegram'].includes(channel)) {
       return NextResponse.json(
-        { error: 'channel must be one of: discord, slack, email, telegram' },
+        { error: 'channel must be one of: discord, discord_dm, slack, email, telegram' },
         { status: 400 }
       );
     }
@@ -50,6 +50,13 @@ export async function POST(request: NextRequest) {
           discord_guild_name: null,
           discord_channel_id: null,
           discord_webhook_url: null,
+        };
+        break;
+      case 'discord_dm':
+        clearData = {
+          discord_dm_connected: false,
+          discord_dm_user_id: null,
+          discord_dm_username: null,
         };
         break;
       case 'slack':

--- a/app/src/app/api/discord/dm-auth-url/route.ts
+++ b/app/src/app/api/discord/dm-auth-url/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const projectId = request.nextUrl.searchParams.get('project_id');
+  if (!projectId) {
+    return NextResponse.json({ error: 'project_id is required' }, { status: 400 });
+  }
+
+  const { data: project, error } = await supabase
+    .from('projects')
+    .select('id')
+    .eq('id', projectId)
+    .eq('user_id', session.user.id)
+    .single();
+
+  if (error || !project) {
+    return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+  }
+
+  const clientId = process.env.DISCORD_CLIENT_ID;
+  const redirectUri = process.env.DISCORD_REDIRECT_URI?.replace('/api/discord/callback', '/api/discord/dm-callback');
+
+  if (!clientId || !redirectUri) {
+    return NextResponse.json({ error: 'Discord integration not configured' }, { status: 500 });
+  }
+
+  const state = Buffer.from(
+    JSON.stringify({ project_id: projectId, user_id: session.user.id, mode: 'dm' })
+  ).toString('base64');
+
+  // DM-only: no bot permissions needed, just identify the user
+  const params = new URLSearchParams({
+    client_id: clientId,
+    scope: 'identify',
+    response_type: 'code',
+    redirect_uri: redirectUri,
+    state,
+  });
+
+  const authUrl = `https://discord.com/api/oauth2/authorize?${params.toString()}`;
+
+  return NextResponse.json({ auth_url: authUrl });
+}

--- a/app/src/app/api/discord/dm-callback/route.ts
+++ b/app/src/app/api/discord/dm-callback/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient, createServiceClient } from '@/lib/supabase/server';
+
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get('code');
+  const stateParam = request.nextUrl.searchParams.get('state');
+
+  if (!code || !stateParam) {
+    return NextResponse.redirect(new URL('/alerts?error=missing_params', request.url));
+  }
+
+  let state: { project_id: string; user_id: string; mode: string };
+  try {
+    state = JSON.parse(Buffer.from(stateParam, 'base64').toString('utf-8'));
+  } catch {
+    return NextResponse.redirect(new URL('/alerts?error=invalid_state', request.url));
+  }
+
+  if (state.mode !== 'dm') {
+    return NextResponse.redirect(new URL('/alerts?error=invalid_mode', request.url));
+  }
+
+  const supabase = await createClient();
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session || session.user.id !== state.user_id) {
+    return NextResponse.redirect(new URL('/alerts?error=unauthorized', request.url));
+  }
+
+  const clientId = process.env.DISCORD_CLIENT_ID;
+  const clientSecret = process.env.DISCORD_CLIENT_SECRET;
+  const redirectUri = process.env.DISCORD_REDIRECT_URI?.replace('/api/discord/callback', '/api/discord/dm-callback');
+
+  if (!clientId || !clientSecret || !redirectUri) {
+    return NextResponse.redirect(new URL('/alerts?error=server_config', request.url));
+  }
+
+  try {
+    // Exchange code for access token
+    const tokenResponse = await fetch('https://discord.com/api/v10/oauth2/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: redirectUri,
+      }),
+    });
+
+    if (!tokenResponse.ok) {
+      console.error('DM token exchange failed:', await tokenResponse.text());
+      return NextResponse.redirect(new URL('/alerts?error=token_exchange', request.url));
+    }
+
+    const tokenData = await tokenResponse.json();
+
+    // Fetch the user's Discord profile
+    const userResponse = await fetch('https://discord.com/api/v10/users/@me', {
+      headers: { Authorization: `Bearer ${tokenData.access_token}` },
+    });
+
+    if (!userResponse.ok) {
+      console.error('Discord user fetch failed:', await userResponse.text());
+      return NextResponse.redirect(new URL('/alerts?error=user_fetch', request.url));
+    }
+
+    const discordUser = await userResponse.json();
+
+    // Save the Discord user ID for DM delivery
+    const serviceClient = await createServiceClient();
+
+    const { error: configError } = await serviceClient
+      .from('outreach_configs')
+      .upsert(
+        {
+          project_id: state.project_id,
+          discord_dm_user_id: discordUser.id,
+          discord_dm_username: `${discordUser.username}${discordUser.discriminator !== '0' ? `#${discordUser.discriminator}` : ''}`,
+          discord_dm_connected: true,
+        },
+        { onConflict: 'project_id' }
+      );
+
+    if (configError) {
+      console.error('DM config update failed:', configError);
+      return new NextResponse(
+        `<!DOCTYPE html>
+<html><head><title>Connection Failed</title></head>
+<body style="font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#f9fafb">
+<p style="font-size:18px;color:#b91c1c">Discord DM connection failed. Please try again.</p>
+</body></html>`,
+        { status: 200, headers: { 'Content-Type': 'text/html' } }
+      );
+    }
+
+    return new NextResponse(
+      `<!DOCTYPE html>
+<html><head><title>Discord DMs Connected</title></head>
+<body style="font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#f9fafb">
+<p style="font-size:18px;color:#111">Discord DMs connected! You can close this window.</p>
+<script>setTimeout(()=>window.close(),1500)</script>
+</body></html>`,
+      { status: 200, headers: { 'Content-Type': 'text/html' } }
+    );
+  } catch (error) {
+    console.error('Discord DM callback error:', error);
+    return NextResponse.redirect(new URL('/alerts?error=unknown', request.url));
+  }
+}

--- a/app/src/app/api/outreach/signals/route.ts
+++ b/app/src/app/api/outreach/signals/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { detectSignalsV3 } from '@/lib/outreach/detector';
 
+/**
+ * GET /api/outreach/signals
+ * Returns existing signals from DB instantly — no scanning.
+ */
 export async function GET(request: NextRequest) {
   try {
     const projectId = request.nextUrl.searchParams.get('project_id');
@@ -10,163 +13,6 @@ export async function GET(request: NextRequest) {
     }
 
     const supabase = await createClient();
-
-    // Get outreach config (table or row may not exist yet)
-    let config: Record<string, unknown> | null = null;
-    try {
-      const { data } = await supabase
-        .from('outreach_configs')
-        .select('*')
-        .eq('project_id', projectId)
-        .maybeSingle();
-      config = data;
-    } catch {
-      // Table may not exist yet
-    }
-
-    // Get project info — always needed
-    const { data: project } = await supabase
-      .from('projects')
-      .select('product_name, product_description, target_audience')
-      .eq('id', projectId)
-      .single();
-
-    if (!project) {
-      return NextResponse.json({ error: 'Project not found' }, { status: 404 });
-    }
-
-    // Get project subreddits
-    const { data: subreddits } = await supabase
-      .from('subreddits')
-      .select('name')
-      .eq('project_id', projectId);
-
-    const subNames = subreddits?.map((s: { name: string }) => s.name) || [];
-
-    if (subNames.length === 0) {
-      return NextResponse.json({ error: 'No subreddits configured. Add subreddits to your project first.' }, { status: 400 });
-    }
-
-    // Derive keywords: check outreach_keywords table first, then config.keywords, then auto-generate
-    let keywords: string[] = [];
-
-    // 1. Try outreach_keywords table (managed by wizard/keyword manager)
-    try {
-      const { data: keywordRows } = await supabase
-        .from('outreach_keywords')
-        .select('phrases')
-        .eq('project_id', projectId)
-        .eq('is_active', true);
-
-      if (keywordRows?.length) {
-        keywords = keywordRows.flatMap((k: { phrases: string[] }) => k.phrases);
-      }
-    } catch {
-      // Table may not exist yet
-    }
-
-    // 2. Fall back to config.keywords
-    if (keywords.length === 0) {
-      keywords = (config?.keywords as string[]) || [];
-    }
-
-    // 3. Auto-generate from product info as last resort
-    if (keywords.length === 0) {
-      // Use the product name as a phrase keyword instead of splitting into single words
-      keywords = [project.product_name];
-      // Add target audience as a keyword if available
-      if (project.target_audience) {
-        keywords.push(project.target_audience);
-      }
-    }
-
-    const competitors: string[] = (config?.competitors as string[]) || [];
-
-    console.log('[Signals] Subreddits:', subNames);
-    console.log('[Signals] Keywords:', keywords);
-    console.log('[Signals] Competitors:', competitors);
-
-    // Check if we need to detect new signals (if none exist or latest is older than 30 min)
-    let latestSignal: { fetched_at: string } | null = null;
-    try {
-      const { data } = await supabase
-        .from('outreach_signals')
-        .select('fetched_at')
-        .eq('project_id', projectId)
-        .order('fetched_at', { ascending: false })
-        .limit(1)
-        .maybeSingle();
-      latestSignal = data;
-    } catch {
-      // Table may not exist yet — will be created by detection pipeline or migration
-    }
-
-    // Read scan preferences from query params (overrides config)
-    const paramTimeFilter = request.nextUrl.searchParams.get('time_filter');
-    const paramMaxResults = request.nextUrl.searchParams.get('max_results');
-    const paramIncludeComments = request.nextUrl.searchParams.get('include_comments');
-
-    const effectiveTimeFilter = paramTimeFilter || (config?.time_filter as string) || 'week';
-    const effectiveMaxResults = paramMaxResults ? parseInt(paramMaxResults, 10) : (config?.max_results as number) || 100;
-    const effectiveIncludeComments = paramIncludeComments !== null
-      ? paramIncludeComments !== 'false'
-      : (config?.include_comments as boolean) ?? true;
-
-    const forceRefresh = request.nextUrl.searchParams.get('force') === 'true';
-    const staleThreshold = 30 * 60 * 1000; // 30 minutes
-    const isStale = !latestSignal ||
-      Date.now() - new Date(latestSignal.fetched_at).getTime() > staleThreshold;
-
-    if (isStale || forceRefresh) {
-      // Fetch product context if available (table may not exist yet)
-      let productContextOption: {
-        problemsSolved: string[];
-        solutionFeatures: string[];
-        audienceBehaviors: string[];
-        competitorWeaknesses: string[];
-      } | undefined;
-
-      try {
-        const { data: productCtx } = await supabase
-          .from('outreach_product_context')
-          .select('problems_solved, solution_features, audience_behaviors, competitor_weaknesses')
-          .eq('project_id', projectId)
-          .maybeSingle();
-
-        if (productCtx) {
-          productContextOption = {
-            problemsSolved: productCtx.problems_solved || [],
-            solutionFeatures: productCtx.solution_features || [],
-            audienceBehaviors: productCtx.audience_behaviors || [],
-            competitorWeaknesses: productCtx.competitor_weaknesses || [],
-          };
-        }
-      } catch {
-        // Table may not exist yet, skip product context
-      }
-
-      // Always run inline detection for immediate results.
-      // Queue-based scanning is handled by the cron job (/api/cron/poll-signals).
-      try {
-        await detectSignalsV3(supabase, {
-          projectId,
-          keywords,
-          competitors,
-          subreddits: subNames,
-          subredditLimit: (config?.subreddit_limit as number) || 20,
-          productName: project.product_name,
-          productDescription: project.product_description,
-          productContext: productContextOption,
-          timeFilter: effectiveTimeFilter as 'hour' | 'day' | 'week' | 'month' | 'year' | 'all',
-          maxResults: effectiveMaxResults,
-          includeComments: effectiveIncludeComments,
-          browseSubreddits: true,
-        });
-      } catch (detectError) {
-        console.error('Signal detection error:', detectError);
-        // Detection failed but we can still return existing signals
-      }
-    }
 
     // Fetch signals with filters
     const status = request.nextUrl.searchParams.get('status');
@@ -236,13 +82,11 @@ export async function GET(request: NextRequest) {
       const { data: signals, error } = await query.limit(100);
 
       if (error) {
-        // Table may not exist yet — return empty signals
         return NextResponse.json({ signals: [] });
       }
 
       return NextResponse.json({ signals: signals || [] });
     } catch {
-      // outreach_signals table may not exist — return empty
       return NextResponse.json({ signals: [] });
     }
   } catch (error) {

--- a/app/src/app/api/outreach/signals/scan/route.ts
+++ b/app/src/app/api/outreach/signals/scan/route.ts
@@ -1,0 +1,154 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { detectSignalsV3 } from '@/lib/outreach/detector';
+
+export const maxDuration = 120;
+
+/**
+ * POST /api/outreach/signals/scan
+ * Kicks off the V3 detection pipeline. Returns immediately with { started: true }.
+ * The scan runs in the background — the client polls GET /api/outreach/signals for results.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const projectId = body.project_id;
+
+    if (!projectId) {
+      return NextResponse.json({ error: 'project_id is required' }, { status: 400 });
+    }
+
+    const supabase = await createClient();
+
+    // Validate session
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Get project info
+    const { data: project } = await supabase
+      .from('projects')
+      .select('product_name, product_description, target_audience')
+      .eq('id', projectId)
+      .single();
+
+    if (!project) {
+      return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+    }
+
+    // Get subreddits
+    const { data: subreddits } = await supabase
+      .from('subreddits')
+      .select('name')
+      .eq('project_id', projectId);
+
+    const subNames = subreddits?.map((s: { name: string }) => s.name) || [];
+
+    if (subNames.length === 0) {
+      return NextResponse.json({ error: 'No subreddits configured.' }, { status: 400 });
+    }
+
+    // Get config
+    let config: Record<string, unknown> | null = null;
+    try {
+      const { data } = await supabase
+        .from('outreach_configs')
+        .select('*')
+        .eq('project_id', projectId)
+        .maybeSingle();
+      config = data;
+    } catch {
+      // Config may not exist
+    }
+
+    // Derive keywords
+    let keywords: string[] = [];
+    try {
+      const { data: keywordRows } = await supabase
+        .from('outreach_keywords')
+        .select('phrases')
+        .eq('project_id', projectId)
+        .eq('is_active', true);
+
+      if (keywordRows?.length) {
+        keywords = keywordRows.flatMap((k: { phrases: string[] }) => k.phrases);
+      }
+    } catch {
+      // Table may not exist
+    }
+
+    if (keywords.length === 0) {
+      keywords = (config?.keywords as string[]) || [];
+    }
+    if (keywords.length === 0) {
+      keywords = [project.product_name];
+      if (project.target_audience) {
+        keywords.push(project.target_audience);
+      }
+    }
+
+    const competitors: string[] = (config?.competitors as string[]) || [];
+
+    // Read scan preferences from body
+    const timeFilter = body.time_filter || (config?.time_filter as string) || 'week';
+    const maxResults = body.max_results || (config?.max_results as number) || 100;
+    const includeComments = body.include_comments ?? (config?.include_comments as boolean) ?? true;
+
+    // Fetch product context
+    let productContext: {
+      problemsSolved: string[];
+      solutionFeatures: string[];
+      audienceBehaviors: string[];
+      competitorWeaknesses: string[];
+    } | undefined;
+
+    try {
+      const { data: productCtx } = await supabase
+        .from('outreach_product_context')
+        .select('problems_solved, solution_features, audience_behaviors, competitor_weaknesses')
+        .eq('project_id', projectId)
+        .maybeSingle();
+
+      if (productCtx) {
+        productContext = {
+          problemsSolved: productCtx.problems_solved || [],
+          solutionFeatures: productCtx.solution_features || [],
+          audienceBehaviors: productCtx.audience_behaviors || [],
+          competitorWeaknesses: productCtx.competitor_weaknesses || [],
+        };
+      }
+    } catch {
+      // Table may not exist
+    }
+
+    // Fire-and-forget: run detection without awaiting
+    detectSignalsV3(supabase, {
+      projectId,
+      keywords,
+      competitors,
+      subreddits: subNames,
+      subredditLimit: (config?.subreddit_limit as number) || 20,
+      productName: project.product_name,
+      productDescription: project.product_description,
+      productContext,
+      timeFilter: timeFilter as 'hour' | 'day' | 'week' | 'month' | 'year' | 'all',
+      maxResults,
+      includeComments,
+      browseSubreddits: true,
+    }).then((count) => {
+      console.log(`[Scan] Completed for project ${projectId}: ${count} signals`);
+    }).catch((err) => {
+      console.error(`[Scan] Failed for project ${projectId}:`, err);
+    });
+
+    // Return immediately
+    return NextResponse.json({ started: true });
+  } catch (error) {
+    console.error('Scan trigger error:', error);
+    return NextResponse.json({ error: 'Failed to start scan' }, { status: 500 });
+  }
+}

--- a/app/src/app/projects/[id]/outreach/alerts/page.tsx
+++ b/app/src/app/projects/[id]/outreach/alerts/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useCallback, useState } from 'react';
-import { Loader2, Wifi, Hash, Mail, Send, Plus, ChevronDown, ChevronUp, Settings } from 'lucide-react';
+import { Loader2, Wifi, Hash, Mail, Send, Plus, ChevronDown, ChevronUp, Settings, MessageCircle } from 'lucide-react';
 import { useProject } from '@/contexts/project-context';
 import { PageTransition } from '@/components/motion';
 import { Header } from '@/components/layout/header';
@@ -14,6 +14,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { DiscordConnect } from '@/components/outreach/DiscordConnect';
+import { DiscordDmConnect } from '@/components/outreach/DiscordDmConnect';
 import { SlackConnect } from '@/components/outreach/SlackConnect';
 import { EmailConnect } from '@/components/outreach/EmailConnect';
 import { TelegramConnect } from '@/components/outreach/TelegramConnect';
@@ -28,6 +29,7 @@ import type { AlertChannel } from '@/types';
 
 const channelMeta: Record<AlertChannel, { icon: React.ComponentType<{ className?: string }>; label: string }> = {
   discord: { icon: Wifi, label: 'Discord' },
+  discord_dm: { icon: MessageCircle, label: 'Discord DM' },
   slack: { icon: Hash, label: 'Slack' },
   email: { icon: Mail, label: 'Email' },
   telegram: { icon: Send, label: 'Telegram' },
@@ -68,9 +70,10 @@ export default function OutreachAlertsPage() {
     fetchAlertDeliveries(project.id);
   }, [project.id, fetchConfig, fetchKeywords, fetchMonitoredSubs, fetchAlertDeliveries]);
 
-  const connectedChannels: AlertChannel[] = (['discord', 'slack', 'email', 'telegram'] as AlertChannel[]).filter((ch) => {
+  const connectedChannels: AlertChannel[] = (['discord', 'discord_dm', 'slack', 'email', 'telegram'] as AlertChannel[]).filter((ch) => {
     switch (ch) {
       case 'discord': return !!config?.discord_connected;
+      case 'discord_dm': return !!config?.discord_dm_connected;
       case 'slack': return !!config?.slack_connected;
       case 'email': return !!config?.email_connected;
       case 'telegram': return !!config?.telegram_connected;
@@ -269,6 +272,11 @@ export default function OutreachAlertsPage() {
               config={config}
               projectId={project.id}
               onDisconnect={() => handleDisconnect('discord')}
+            />
+            <DiscordDmConnect
+              config={config}
+              projectId={project.id}
+              onDisconnect={() => handleDisconnect('discord_dm')}
             />
             <SlackConnect
               config={config}

--- a/app/src/app/projects/[id]/outreach/signals/page.tsx
+++ b/app/src/app/projects/[id]/outreach/signals/page.tsx
@@ -115,39 +115,75 @@ export default function OutreachSignalsPage() {
 
   async function handleScanNow() {
     setScanning(true);
+    const beforeCount = signals.length;
     try {
-      // Fetch current config to get scan params
-      let scanParams = '';
+      // Get scan params from config
+      let scanBody: Record<string, unknown> = { project_id: project.id };
       try {
         const configRes = await fetch(`/api/outreach/config?project_id=${project.id}`);
         const configJson = await configRes.json();
         if (configJson.config) {
           const c = configJson.config;
-          const p = new URLSearchParams();
-          if (c.time_filter) p.set('time_filter', c.time_filter);
-          if (c.max_results) p.set('max_results', String(c.max_results));
-          if (c.include_comments !== undefined) p.set('include_comments', String(c.include_comments));
-          scanParams = p.toString();
+          if (c.time_filter) scanBody.time_filter = c.time_filter;
+          if (c.max_results) scanBody.max_results = c.max_results;
+          if (c.include_comments !== undefined) scanBody.include_comments = c.include_comments;
         }
       } catch {
         // Use defaults
       }
 
-      const url = `/api/outreach/signals?project_id=${project.id}&force=true${scanParams ? `&${scanParams}` : ''}`;
-      const res = await fetch(url);
+      // Fire off background scan — returns immediately
+      const res = await fetch('/api/outreach/signals/scan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(scanBody),
+      });
       const json = await res.json();
       if (json.error) {
         toast.error(json.error);
-      } else {
-        toast.success(`Found ${json.signals?.length || 0} signals`);
-        setSignals(json.signals || []);
-        setLastScanned(new Date().toISOString());
-        fetchAnalytics();
+        setScanning(false);
+        return;
       }
+
+      toast('Scanning in background...', { duration: 3000 });
+
+      // Poll for new results every 3s for up to 2 minutes
+      let polls = 0;
+      const maxPolls = 40;
+      const pollInterval = setInterval(async () => {
+        polls++;
+        try {
+          const params = new URLSearchParams({ project_id: project.id, status: 'new' });
+          if (subFilter) params.set('subreddit', subFilter);
+          const pollRes = await fetch(`/api/outreach/signals?${params}`);
+          const pollJson = await pollRes.json();
+          const newSignals = pollJson.signals || [];
+
+          if (newSignals.length > beforeCount) {
+            setSignals(newSignals);
+            setLastScanned(new Date().toISOString());
+            fetchAnalytics();
+            toast.success(`Found ${newSignals.length} signals`);
+            clearInterval(pollInterval);
+            setScanning(false);
+          } else if (polls >= maxPolls) {
+            // Timed out — show whatever we have
+            setSignals(newSignals);
+            fetchAnalytics();
+            clearInterval(pollInterval);
+            setScanning(false);
+            if (newSignals.length === beforeCount) {
+              toast('No new signals found', { duration: 3000 });
+            }
+          }
+        } catch {
+          // Keep polling
+        }
+      }, 3000);
     } catch {
       toast.error('Scan failed');
+      setScanning(false);
     }
-    setScanning(false);
   }
 
   async function handleStatusChange(signalId: string, status: string) {

--- a/app/src/components/onboarding/steps/SubredditsStep.tsx
+++ b/app/src/components/onboarding/steps/SubredditsStep.tsx
@@ -120,11 +120,11 @@ export function SubredditsStep({
         // server route failed
       }
 
-      // 2. Fallback: call Reddit directly from the browser (user's IP won't be blocked)
+      // 2. Fallback: call Reddit via old.reddit.com (www.reddit.com blocks CORS)
       if (results.length === 0) {
         try {
           const res = await fetch(
-            `https://www.reddit.com/subreddits/search.json?q=${encodeURIComponent(query)}&limit=8&raw_json=1`,
+            `https://old.reddit.com/subreddits/search.json?q=${encodeURIComponent(query)}&limit=8&raw_json=1`,
             { headers: { Accept: 'application/json' } }
           );
           if (res.ok) {
@@ -143,7 +143,7 @@ export function SubredditsStep({
       }
 
       setSearchResults(results);
-      if (results.length > 0) setShowDropdown(true);
+      setShowDropdown(results.length > 0);
       setSearchLoading(false);
     }, 300);
 
@@ -244,7 +244,7 @@ export function SubredditsStep({
         </div>
 
         {showDropdown && searchResults.length > 0 && (
-          <div className="absolute z-10 mt-1 w-full rounded-xl border bg-card shadow-lg overflow-hidden">
+          <div className="absolute z-50 mt-1 w-full rounded-xl border bg-card shadow-lg overflow-hidden">
             {searchResults.map((result) => {
               const alreadyAdded = addedSubs.some((s) => s.name.toLowerCase() === result.name.toLowerCase());
               return (

--- a/app/src/components/outreach/AlertHistory.tsx
+++ b/app/src/components/outreach/AlertHistory.tsx
@@ -21,6 +21,7 @@ const statusConfig: Record<string, { icon: React.ComponentType<{ className?: str
 
 const channelConfig: Record<AlertChannel, { icon: React.ComponentType<{ className?: string }>; label: string; color: string }> = {
   discord: { icon: MessageSquare, label: 'Discord', color: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-300' },
+  discord_dm: { icon: MessageSquare, label: 'Discord DM', color: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-300' },
   slack: { icon: Hash, label: 'Slack', color: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300' },
   email: { icon: Mail, label: 'Email', color: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300' },
   telegram: { icon: Send, label: 'Telegram', color: 'bg-sky-100 text-sky-800 dark:bg-sky-900 dark:text-sky-300' },
@@ -29,6 +30,7 @@ const channelConfig: Record<AlertChannel, { icon: React.ComponentType<{ classNam
 const filterOptions: { value: AlertChannel | 'all'; label: string }[] = [
   { value: 'all', label: 'All' },
   { value: 'discord', label: 'Discord' },
+  { value: 'discord_dm', label: 'Discord DM' },
   { value: 'slack', label: 'Slack' },
   { value: 'email', label: 'Email' },
   { value: 'telegram', label: 'Telegram' },

--- a/app/src/components/outreach/AlertsSetupWizard.tsx
+++ b/app/src/components/outreach/AlertsSetupWizard.tsx
@@ -21,6 +21,7 @@ import { slideHorizontalVariants } from '@/lib/motion';
 import { useOutreachStore } from '@/stores/outreach-store';
 import { useProject } from '@/contexts/project-context';
 import { DiscordConnect } from '@/components/outreach/DiscordConnect';
+import { DiscordDmConnect } from '@/components/outreach/DiscordDmConnect';
 import { SlackConnect } from '@/components/outreach/SlackConnect';
 import { EmailConnect } from '@/components/outreach/EmailConnect';
 import { TelegramConnect } from '@/components/outreach/TelegramConnect';
@@ -154,10 +155,11 @@ export function AlertsSetupWizard({
 
   // Channel helpers
   const connectedChannels: AlertChannel[] = (
-    ['discord', 'slack', 'email', 'telegram'] as AlertChannel[]
+    ['discord', 'discord_dm', 'slack', 'email', 'telegram'] as AlertChannel[]
   ).filter((ch) => {
     switch (ch) {
       case 'discord': return !!config?.discord_connected;
+      case 'discord_dm': return !!config?.discord_dm_connected;
       case 'slack': return !!config?.slack_connected;
       case 'email': return !!config?.email_connected;
       case 'telegram': return !!config?.telegram_connected;
@@ -352,6 +354,11 @@ export function AlertsSetupWizard({
                     config={config}
                     projectId={projectId}
                     onDisconnect={() => disconnectChannel(projectId, 'discord')}
+                  />
+                  <DiscordDmConnect
+                    config={config}
+                    projectId={projectId}
+                    onDisconnect={() => disconnectChannel(projectId, 'discord_dm')}
                   />
                   <SlackConnect
                     config={config}

--- a/app/src/components/outreach/DiscordDmConnect.tsx
+++ b/app/src/components/outreach/DiscordDmConnect.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { Loader2, Unplug, MessageCircle } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { toast } from 'sonner';
+import type { OutreachConfig } from '@/types';
+
+interface DiscordDmConnectProps {
+  config: OutreachConfig | null;
+  projectId: string;
+  onDisconnect: () => void;
+}
+
+export function DiscordDmConnect({ config, projectId, onDisconnect }: DiscordDmConnectProps) {
+  const [connecting, setConnecting] = useState(false);
+  const [polling, setPolling] = useState(false);
+  const pollCountRef = useRef(0);
+
+  const isConnected = config?.discord_dm_connected && config?.discord_dm_user_id;
+
+  useEffect(() => {
+    if (!polling) return;
+
+    pollCountRef.current = 0;
+
+    const interval = setInterval(async () => {
+      pollCountRef.current += 1;
+
+      if (pollCountRef.current > 40) {
+        setPolling(false);
+        clearInterval(interval);
+        toast.error('Discord DM connection timed out. Please try again.');
+        return;
+      }
+
+      try {
+        const res = await fetch(`/api/outreach/config?project_id=${projectId}`);
+        const json = await res.json();
+
+        if (json?.config?.discord_dm_connected) {
+          setPolling(false);
+          clearInterval(interval);
+          toast.success('Discord DMs connected!');
+          window.location.reload();
+        }
+      } catch {
+        // Silently retry on network errors
+      }
+    }, 3000);
+
+    return () => clearInterval(interval);
+  }, [polling, projectId]);
+
+  async function handleConnect() {
+    setConnecting(true);
+    try {
+      const res = await fetch(`/api/discord/dm-auth-url?project_id=${projectId}`);
+      const json = await res.json();
+
+      if (json.error) {
+        toast.error(json.error);
+      } else if (json.auth_url) {
+        window.open(json.auth_url, '_blank', 'width=600,height=700');
+        setPolling(true);
+      }
+    } catch {
+      toast.error('Failed to start Discord DM connection');
+    }
+    setConnecting(false);
+  }
+
+  if (isConnected) {
+    return (
+      <Card>
+        <CardContent className="p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <MessageCircle className="h-4 w-4 text-green-500" />
+              <span className="font-medium text-sm">Discord DMs</span>
+              <Badge variant="secondary" className="text-[10px] bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">
+                Active
+              </Badge>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-xs text-muted-foreground"
+              onClick={onDisconnect}
+            >
+              <Unplug className="mr-1 h-3 w-3" />
+              Disconnect
+            </Button>
+          </div>
+          <div className="text-xs text-muted-foreground">
+            <p>Receiving alerts via DM as <span className="font-medium text-foreground">{config?.discord_dm_username}</span></p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-center gap-2">
+          <MessageCircle className="h-4 w-4 text-muted-foreground" />
+          <span className="font-medium text-sm">Discord DMs</span>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Get alerts delivered directly to your Discord DMs. No server needed — just authorize your account.
+        </p>
+        <div className="flex items-center gap-2">
+          <Button onClick={handleConnect} disabled={connecting || polling} size="sm">
+            {connecting && <Loader2 className="mr-2 h-3 w-3 animate-spin" />}
+            Connect DMs
+          </Button>
+          {polling && (
+            <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Waiting for connection...
+            </span>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/src/components/outreach/SignalCard.tsx
+++ b/app/src/components/outreach/SignalCard.tsx
@@ -5,12 +5,10 @@ import {
   ArrowUpRight, MessageSquare, Clock, ExternalLink, X, Bell,
   Star, Flame, Sun, Pencil,
 } from 'lucide-react';
-import { motion } from 'motion/react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { cardHover, cardTap } from '@/lib/motion';
 import { ReplyBuilder } from '@/components/outreach/ReplyBuilder';
 import { toast } from 'sonner';
 import type { OutreachSignal, SignalType, LeadTier, BuyerIntent } from '@/types';
@@ -178,7 +176,7 @@ export function SignalCard({ signal, projectId, onStatusChange, onFavoriteToggle
   }
 
   return (
-    <motion.div whileHover={cardHover} whileTap={cardTap} className="h-full" onClick={handleCardClick}>
+    <div className="h-full" onClick={handleCardClick}>
       <Card className={`transition-shadow hover:shadow-md h-full flex flex-col relative overflow-hidden ${
         tier === 'hot'
           ? 'border-red-500/60 border-[1.5px]'
@@ -404,6 +402,6 @@ export function SignalCard({ signal, projectId, onStatusChange, onFavoriteToggle
           )}
         </CardContent>
       </Card>
-    </motion.div>
+    </div>
   );
 }

--- a/app/src/lib/ai/client.ts
+++ b/app/src/lib/ai/client.ts
@@ -18,6 +18,6 @@ export function getAnthropicClient(): Anthropic {
   return client;
 }
 
-export const AI_MODEL = 'claude-sonnet-4-5-20250929';
+export const AI_MODEL = 'claude-opus-4-6';
 export const HAIKU_MODEL = 'claude-haiku-4-5-20251001';
 export const MAX_TOKENS = 4096;

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -268,6 +268,10 @@ export interface OutreachConfig {
   email_digest_enabled: boolean;
   email_digest_frequency: 'daily' | 'weekly' | null;
   email_last_digest_at: string | null;
+  // Discord DM integration
+  discord_dm_user_id: string | null;
+  discord_dm_username: string | null;
+  discord_dm_connected: boolean;
   // Telegram integration
   telegram_chat_id: string | null;
   telegram_username: string | null;
@@ -353,7 +357,7 @@ export type Urgency = 'none' | 'low' | 'medium' | 'high';
 
 export type DiscoverySource = 'subreddit_browse' | 'keyword_search' | 'comment_search' | 'both';
 
-export type AlertChannel = 'discord' | 'slack' | 'email' | 'telegram';
+export type AlertChannel = 'discord' | 'discord_dm' | 'slack' | 'email' | 'telegram';
 
 export interface AlertDelivery {
   id: string;

--- a/services/discord-bot/src/bot/client.ts
+++ b/services/discord-bot/src/bot/client.ts
@@ -24,7 +24,7 @@ commands.set(addCommand.data.name, addCommand);
 
 export function createBot(): Client {
   const client = new Client({
-    intents: [GatewayIntentBits.Guilds],
+    intents: [GatewayIntentBits.Guilds, GatewayIntentBits.DirectMessages],
   });
 
   client.once(Events.ClientReady, async (readyClient) => {

--- a/services/discord-bot/src/index.ts
+++ b/services/discord-bot/src/index.ts
@@ -1,4 +1,5 @@
 import 'dotenv/config';
+import { Client } from 'discord.js';
 import { createBot } from './bot/client.js';
 import { startPoller } from './services/poller.js';
 
@@ -8,12 +9,20 @@ if (!token) {
   throw new Error('Missing DISCORD_BOT_TOKEN environment variable');
 }
 
+/** Shared bot client instance, available after login. */
+let botClient: Client | null = null;
+
+export function getBotClient(): Client | null {
+  return botClient;
+}
+
 async function main() {
   console.log('Starting SuperReddit Discord Bot...');
 
   // Start the Discord bot
   const bot = createBot();
   await bot.login(token);
+  botClient = bot;
 
   // Start the Reddit polling service
   startPoller();

--- a/services/discord-bot/src/services/dispatcher.ts
+++ b/services/discord-bot/src/services/dispatcher.ts
@@ -2,6 +2,8 @@ import { supabase } from '../db/supabase.js';
 import { sendSlackAlert } from './slack-dispatcher.js';
 import { sendEmailAlert } from './email-dispatcher.js';
 import { sendTelegramAlert } from './telegram-dispatcher.js';
+import { sendDmAlert } from './dm-dispatcher.js';
+import { getBotClient } from '../index.js';
 
 interface SignalEmbed {
   signalId: string;
@@ -257,6 +259,16 @@ export async function dispatchMultiChannelAlerts(projectId: string, config: any)
             });
           }
           break;
+        case 'discord_dm': {
+          const client = getBotClient();
+          if (client && config.discord_dm_user_id) {
+            success = await sendDmAlert(client, config.discord_dm_user_id, {
+              ...payload,
+              detectedAt: signal.fetched_at || signal.created_at,
+            });
+          }
+          break;
+        }
         case 'slack':
           if (config.slack_webhook_url) {
             success = await sendSlackAlert(config.slack_webhook_url, payload);

--- a/services/discord-bot/src/services/dm-dispatcher.ts
+++ b/services/discord-bot/src/services/dm-dispatcher.ts
@@ -1,0 +1,115 @@
+import { Client, EmbedBuilder } from 'discord.js';
+
+interface DmSignalPayload {
+  title: string;
+  subreddit: string;
+  matchedKeywords: string[];
+  snippet: string;
+  redditUrl: string;
+  redditAuthor: string | null;
+  signalTypes: string[];
+  combinedScore: number;
+  painSeverity: string | null;
+  decisionMaker: boolean;
+  detectedAt: string;
+}
+
+const SIGNAL_TYPE_BADGES: Record<string, string> = {
+  tool_switch: '🔄',
+  budget_constraint: '💰',
+  repeated_pain: '😫',
+  high_signal_comment: '🎯',
+  mod_safe: '✅',
+  trend_cluster: '📈',
+  convertible_thread: '🔥',
+};
+
+const PAIN_BADGES: Record<string, string> = {
+  low: '🟢',
+  medium: '🟡',
+  high: '🔴',
+};
+
+function getScoreColor(score: number): number {
+  if (score >= 0.7) return 0x22c55e;
+  if (score >= 0.4) return 0xf59e0b;
+  return 0xef4444;
+}
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength - 3) + '...';
+}
+
+/**
+ * Send a signal alert as a Discord DM to a user.
+ */
+export async function sendDmAlert(
+  client: Client,
+  discordUserId: string,
+  signal: DmSignalPayload
+): Promise<boolean> {
+  try {
+    const user = await client.users.fetch(discordUserId);
+    if (!user) {
+      console.error(`Could not fetch Discord user ${discordUserId}`);
+      return false;
+    }
+
+    const typeBadges = signal.signalTypes
+      .map((t) => `${SIGNAL_TYPE_BADGES[t] || '📌'} ${t.replace(/_/g, ' ')}`)
+      .join(' | ');
+
+    const appUrl = process.env.APP_URL || 'https://superreddit.app';
+
+    const embed = new EmbedBuilder()
+      .setTitle(truncate(signal.title, 256))
+      .setURL(signal.redditUrl)
+      .setColor(getScoreColor(signal.combinedScore))
+      .setTimestamp(new Date(signal.detectedAt))
+      .setFooter({ text: `SuperReddit | View in app: ${appUrl}` });
+
+    if (signal.snippet) {
+      embed.setDescription(truncate(signal.snippet, 300));
+    }
+
+    embed.addFields(
+      { name: 'Subreddit', value: `r/${signal.subreddit}`, inline: true },
+      { name: 'Score', value: `${signal.combinedScore.toFixed(2)}`, inline: true }
+    );
+
+    if (signal.signalTypes.length > 0) {
+      embed.addFields({ name: 'Signal Types', value: typeBadges, inline: false });
+    }
+
+    if (signal.matchedKeywords.length > 0) {
+      embed.addFields({
+        name: 'Matched Keywords',
+        value: signal.matchedKeywords.map((k) => `\`${k}\``).join(', '),
+        inline: false,
+      });
+    }
+
+    if (signal.painSeverity) {
+      embed.addFields({
+        name: 'Pain Severity',
+        value: `${PAIN_BADGES[signal.painSeverity] || ''} ${signal.painSeverity}`,
+        inline: true,
+      });
+    }
+
+    if (signal.decisionMaker) {
+      embed.addFields({ name: 'Decision Maker', value: '👔 Yes', inline: true });
+    }
+
+    if (signal.redditAuthor) {
+      embed.addFields({ name: 'Author', value: `u/${signal.redditAuthor}`, inline: true });
+    }
+
+    await user.send({ embeds: [embed] });
+    return true;
+  } catch (error) {
+    console.error(`Failed to DM user ${discordUserId}:`, error);
+    return false;
+  }
+}

--- a/services/discord-bot/src/services/poller.ts
+++ b/services/discord-bot/src/services/poller.ts
@@ -47,7 +47,7 @@ async function pollAllProjects() {
       .from('outreach_configs')
       .select('*')
       .eq('polling_enabled', true)
-      .or('discord_connected.eq.true,slack_connected.eq.true,email_connected.eq.true,telegram_connected.eq.true');
+      .or('discord_connected.eq.true,discord_dm_connected.eq.true,slack_connected.eq.true,email_connected.eq.true,telegram_connected.eq.true');
 
     if (error || !configs?.length) return;
 
@@ -70,6 +70,8 @@ async function pollProject(config: {
   project_id: string;
   discord_webhook_url: string;
   discord_connected: boolean;
+  discord_dm_connected: boolean;
+  discord_dm_user_id: string | null;
   slack_connected: boolean;
   slack_webhook_url: string | null;
   email_connected: boolean;
@@ -163,6 +165,7 @@ async function pollProject(config: {
           // Create alert_deliveries for each connected channel
           const channels: string[] = [];
           if (config.discord_connected && config.discord_webhook_url) channels.push('discord');
+          if (config.discord_dm_connected && config.discord_dm_user_id) channels.push('discord_dm');
           if (config.slack_connected && config.slack_webhook_url) channels.push('slack');
           if (config.email_connected && config.email_address) channels.push('email');
           if (config.telegram_connected && config.telegram_chat_id) channels.push('telegram');


### PR DESCRIPTION
## Summary
- **Discord DM alerts**: Solo users can now receive signal alerts directly via Discord DMs without needing a server — new OAuth flow (`identify` scope only), DM dispatcher service, and connect/disconnect UI
- **Async signal scanning**: Signals page loads instantly from DB; "Scan Now" fires detection in background and polls for results instead of blocking the UI for 30-60+ seconds
- **SignalCard fix**: Removed `motion.div` scale animation wrapper that triggered on every click/hover inside the card (typing, buttons, etc.)
- **Subreddit search fix**: Bumped dropdown z-index to z-50 and fixed CORS fallback URL (`www.reddit.com` → `old.reddit.com`)

## Test plan
- [ ] Connect Discord DMs via the new "Discord DMs" card in Alert Channels
- [ ] Verify DM alerts are delivered when new signals are detected
- [ ] Disconnect Discord DMs and verify config is cleared
- [ ] Open Signals page — should load instantly (no scanning on page load)
- [ ] Click "Scan Now" — should show "Scanning in background..." toast and poll for results
- [ ] Interact with SignalCard (click buttons, type in reply builder) — no hover animation on entire card
- [ ] Search for subreddits in onboarding — dropdown should appear with results

🤖 Generated with [Claude Code](https://claude.com/claude-code)