### PR TITLE
Landing page: fix double-laptop and scroll animation

### DIFF
--- a/landing-preview/index.html
+++ b/landing-preview/index.html
@@ -1076,11 +1076,10 @@ window.addEventListener('scroll', () => {
   }
 
   // ── Progress: direct from scroll position (no lerp) ──
-  // Animation plays over 3 viewport heights of scrolling.
-  // With 600vh section, that uses ~50% for animation, ~50% for hold.
+  // Animation completes within ~1.5 viewport heights of scrolling.
   const demoTop = demoRect.top;
   const startThreshold = viewH * 0.8;
-  const scrollDistance = viewH * 3.0;
+  const scrollDistance = viewH * 1.5;
   const rawProgress = (startThreshold - demoTop) / scrollDistance;
   laptopProgress = Math.max(0, Math.min(1, rawProgress));
 
@@ -1088,16 +1087,14 @@ window.addEventListener('scroll', () => {
   // Overlay fades in gradually — no hard switch, no visual jump.
   const shouldShowOverlay = laptopProgress > 0.05;
 
-  // Hero laptop stays visible — it scrolls away with the hero section.
-  // No visibility toggle needed.
+  // Instant swap: hero laptop hides, overlay laptop appears
+  if (heroLaptopNode) heroLaptopNode.visible = !shouldShowOverlay;
 
   const overlayCanvas = document.getElementById('laptop-overlay-canvas');
   if (overlayCanvas) {
     if (shouldShowOverlay && demoRect.bottom >= 0) {
       overlayCanvas.style.display = 'block';
-      // Gradual fade in from 5% to 25% progress — smooth cross-fade
-      const fadeIn = Math.min(1, (laptopProgress - 0.05) / 0.20);
-      overlayCanvas.style.opacity = fadeIn;
+      overlayCanvas.style.opacity = 1;
     } else {
       overlayCanvas.style.display = 'none';
       overlayCanvas.style.opacity = 0;


### PR DESCRIPTION
## Summary
- Fix double-laptop issue: hero laptop instantly hides when overlay animation laptop appears (no ghosting/overlap)
- Overlay laptop snaps to full opacity instead of gradual fade-in that caused visible double
- Speed up laptop spin animation: completes in 1.5vh scroll distance instead of 3.0vh
- Pure native scrolling with 600vh demo section for smooth scroll-driven animation

## Test plan
- [ ] Scroll through the landing page — verify only ONE laptop is visible at all times
- [ ] Verify the laptop spin completes quickly (within ~1.5 viewport heights of scrolling)
- [ ] Scroll back up — hero laptop reappears seamlessly
- [ ] Check at various scroll speeds — no flickering or double laptop at any point
- [ ] Verify the "See it in action" text appears after animation completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)